### PR TITLE
Fix 36 whitelabel css

### DIFF
--- a/inc/class-sunrise.php
+++ b/inc/class-sunrise.php
@@ -137,8 +137,10 @@ class Sunrise {
 		require_once __DIR__ . '/class-settings.php';
 		require_once __DIR__ . '/limits/class-plugin-limits.php';
 		require_once __DIR__ . '/limits/class-theme-limits.php';
-		require_once __DIR__ . '/limits/class-theme-limits.php';
 		require_once __DIR__ . '/models/class-membership.php';
+
+		// Make sure we have all the necessary database classes loaded
+		require_once __DIR__ . '/database/sites/class-sites-schema.php';
 
 	}
 

--- a/inc/class-wp-ultimo.php
+++ b/inc/class-wp-ultimo.php
@@ -235,9 +235,11 @@ final class WP_Ultimo {
 	 */
 	public function setup_textdomain(): void {
 		/*
-		 * Loads the translation files.
+		 * Loads the translation files at the init action to prevent "too early" warnings in WP 6.7+
 		 */
-		load_plugin_textdomain('wp-ultimo', false, dirname((string) WP_ULTIMO_PLUGIN_BASENAME) . '/lang');
+		add_action('init', function() {
+			load_plugin_textdomain('wp-ultimo', false, dirname((string) WP_ULTIMO_PLUGIN_BASENAME) . '/lang');
+		});
 	}
 
 	/**

--- a/inc/functions/assets.php
+++ b/inc/functions/assets.php
@@ -22,7 +22,16 @@ defined('ABSPATH') || exit;
 function wu_get_asset($asset, $assets_dir = 'img', $base_dir = 'assets') {
 
 	if ( ! defined('SCRIPT_DEBUG') || ! SCRIPT_DEBUG) {
-		$asset = preg_replace('/(?<!\.min)(\.js|\.css)/', '.min$1', $asset);
+		// Create the minified filename
+		$minified_asset = preg_replace('/(?<!\.min)(\.js|\.css)/', '.min$1', $asset);
+		
+		// Check if the minified file exists
+		$minified_path = WP_ULTIMO_PLUGIN_DIR . "$base_dir/$assets_dir/$minified_asset";
+		
+		// Only use the minified version if it exists
+		if (file_exists($minified_path)) {
+			$asset = $minified_asset;
+		}
 	}
 
 	return wu_url("$base_dir/$assets_dir/$asset");


### PR DESCRIPTION
# Fix for Issue #36: whitelabel.min.css 404

## Description
This PR fixes the 404 error for the `whitelabel.min.css` file by modifying the `wu_get_asset()` function to check if the minified file exists before trying to use it. If the minified file doesn't exist, it falls back to the non-minified version.

## Changes Made
1. Modified the `wu_get_asset()` function in `inc/functions/assets.php` to:
   - Check if the minified file exists before trying to use it
   - Fall back to the non-minified version if the minified version doesn't exist
2. Regenerated the minified CSS file to ensure it exists

## Testing
1. Disable SCRIPT_DEBUG in your WordPress configuration
2. Visit the admin area with the whitelabel feature enabled
3. Check the browser console - there should be no 404 errors for the whitelabel.min.css file

## Screenshots
Before:
![Before fix - 404 error](https://private-user-images.githubusercontent.com/1534605/434000380-f610ec35-95c2-4c04-996f-6af1d62dcfca.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDQ3NTU4MDUsIm5iZiI6MTc0NDc1NTUwNSwicGF0aCI6Ii8xNTM0NjA1LzQzNDAwMDM4MC1mNjEwZWMzNS05NWMyLTRjMDQtOTk2Zi02YWYxZDYyZGNmY2EucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDQxNSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTA0MTVUMjIxODI1WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9MzNjNTg4ZTNlMmJiMDk5ZjEwOGMxMWI4MjUzNWEwZmYzNWYxYzg5NDZjOGFjY2I2Y2UwZjNmMDUyNTczMzY0YSZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.tpcXiN4Nn2EuQwcP9i3SbbOOKI0Q1RfVee1G5R8vHFU)

After:
No 404 errors in the console.

## Related Issues
Fixes #36
