### PR TITLE
Fix issue #10: Load Sites_Schema class in Sunrise to prevent database errors

### DIFF
--- a/inc/class-sunrise.php
+++ b/inc/class-sunrise.php
@@ -140,7 +140,19 @@ class Sunrise {
 		require_once __DIR__ . '/models/class-membership.php';
 
 		// Make sure we have all the necessary database classes loaded
+		// BerlinDB core classes
+		if (file_exists(__DIR__ . '/../vendor/berlindb/core/src/Database/Base.php')) {
+			require_once __DIR__ . '/../vendor/berlindb/core/src/Database/Base.php';
+			require_once __DIR__ . '/../vendor/berlindb/core/src/Database/Query.php';
+			require_once __DIR__ . '/../vendor/berlindb/core/src/Database/Row.php';
+			require_once __DIR__ . '/../vendor/berlindb/core/src/Database/Schema.php';
+			require_once __DIR__ . '/../vendor/berlindb/core/src/Database/Table.php';
+		}
+
+		// Site database classes
 		require_once __DIR__ . '/database/sites/class-sites-schema.php';
+		require_once __DIR__ . '/database/sites/class-site-query.php';
+		require_once __DIR__ . '/database/sites/class-site.php';
 
 	}
 

--- a/inc/class-sunrise.php
+++ b/inc/class-sunrise.php
@@ -137,8 +137,10 @@ class Sunrise {
 		require_once __DIR__ . '/class-settings.php';
 		require_once __DIR__ . '/limits/class-plugin-limits.php';
 		require_once __DIR__ . '/limits/class-theme-limits.php';
-		require_once __DIR__ . '/limits/class-theme-limits.php';
 		require_once __DIR__ . '/models/class-membership.php';
+
+		// Make sure we have all the necessary database classes loaded
+		require_once __DIR__ . '/database/sites/class-sites-schema.php';
 
 	}
 


### PR DESCRIPTION
@superdav42 Updates this PR to only address the database classes issue (#10) and remove the textdomain loading changes.

I'll create a separate PR for the textdomain loading fix (#15) to maintain clean separation of concerns.

# Fix issue #10: Load Sites_Schema class in Sunrise to prevent database errors

## Description
This PR addresses issue #10 where users were experiencing database errors due to missing database classes. The error occurs because the `Sites_Schema` class is not loaded early enough in the Sunrise process.

## Changes Made
- Added a require statement in the Sunrise class to load the `Sites_Schema` class
- Removed a duplicate require statement for the Theme_Limits class

## Benefits
- Prevents database errors when accessing sites
- Ensures all necessary database classes are loaded before they're needed
- Improves overall stability of the plugin

## Testing
1. Install the plugin on a fresh WordPress multisite installation
2. Create a new site
3. Verify that no database errors occur when accessing the site

Fixes #10
