### PR TITLE
Fix issue #49: Add null checks to prevent errors in domain mapping

### DIFF
--- a/inc/class-domain-mapping.php
+++ b/inc/class-domain-mapping.php
@@ -471,9 +471,22 @@ class Domain_Mapping {
 			$current_mapping = $this->current_mapping;
 		}
 
+		// If we don't have a valid mapping, return the original URL
+		if (!$current_mapping) {
+			return $url;
+		}
+
+		// Get the site associated with the mapping
+		$site = $current_mapping->get_site();
+
+		// If we don't have a valid site, return the original URL
+		if (!$site) {
+			return $url;
+		}
+
 		// Replace the domain
 		$domain_base = wp_parse_url($url, PHP_URL_HOST);
-		$domain      = rtrim($domain_base . '/' . $current_mapping->get_site()->get_path(), '/');
+		$domain      = rtrim($domain_base . '/' . $site->get_path(), '/');
 		$regex       = '#^(\w+://)' . preg_quote($domain, '#') . '#i';
 		$mangled     = preg_replace($regex, '${1}' . $current_mapping->get_domain(), $url);
 
@@ -508,7 +521,13 @@ class Domain_Mapping {
 
 		$current_mapping = $this->current_mapping;
 
+		// Check if we have a valid mapping for this site
 		if (empty($current_mapping) || $current_mapping->get_site_id() !== $site_id) {
+			return $url;
+		}
+
+		// Check if the site exists
+		if (!$current_mapping->get_site()) {
 			return $url;
 		}
 
@@ -523,6 +542,11 @@ class Domain_Mapping {
 	 * @return array
 	 */
 	public function fix_srcset($sources) {
+
+		// Check if we have a valid mapping
+		if (empty($this->current_mapping) || !$this->current_mapping->get_site()) {
+			return $sources;
+		}
 
 		foreach ($sources as &$source) {
 			$sources[ $source['value'] ]['url'] = $this->replace_url($sources[ $source['value'] ]['url']);


### PR DESCRIPTION
# Fix issue #49: Add null checks to prevent errors in domain mapping

## Description
This PR addresses issue #49 where domain mapping is broken in 2.4.0-beta. The error occurs when trying to call `get_path()` on a site object that doesn't exist, resulting in a fatal error:

```
PHP Fatal error: Uncaught Error: Call to a member function get_path() on false in inc/class-domain-mapping.php:476
```

## Changes Made
- Added null checks in the `replace_url` method to verify that both the mapping and site objects exist before trying to use them
- Added similar checks in the `mangle_url` method to prevent errors when the site doesn't exist
- Added checks in the `fix_srcset` method to ensure we have a valid mapping before processing
- Improved code organization by storing the site object in a variable for better readability

## Benefits
- Prevents fatal errors when a domain mapping exists but the associated site doesn't
- Gracefully falls back to the original URL when a mapping is invalid
- Improves overall stability of the domain mapping functionality

## Testing
1. Set up a domain mapping for a site
2. Delete the site but keep the domain mapping
3. Try to access the mapped domain
4. Verify that no fatal errors occur

Fixes #49
