### PR TITLE
Performance Optimization: Implement conditional script and style loading

### DIFF
--- a/inc/class-scripts.php
+++ b/inc/class-scripts.php
@@ -335,7 +335,27 @@ class Scripts {
 	 */
 	public function enqueue_default_admin_styles(): void {
 
-		wp_enqueue_style('wu-admin');
+		// Get current screen to conditionally load styles
+		$screen = get_current_screen();
+
+		if (!$screen) {
+			return;
+		}
+
+		// Only load styles on WP Ultimo admin pages
+		if ($this->is_wp_ultimo_admin_page($screen)) {
+			wp_enqueue_style('wu-admin');
+
+			// Load flag styles only when needed (e.g., on pages with country selection)
+			if ($this->is_wp_ultimo_flags_page($screen)) {
+				wp_enqueue_style('wu-flags');
+			}
+		}
+
+		// Load checkout styles only on checkout pages
+		if (isset($_GET['page']) && strpos($_GET['page'], 'wu-checkout') === 0) {
+			wp_enqueue_style('wu-checkout');
+		}
 	}
 
 	/**
@@ -346,7 +366,32 @@ class Scripts {
 	 */
 	public function enqueue_default_admin_scripts(): void {
 
-		wp_enqueue_script('wu-admin');
+		// Get current screen to conditionally load scripts
+		$screen = get_current_screen();
+
+		if (!$screen) {
+			return;
+		}
+
+		// Base admin script for all WP Ultimo admin pages
+		if ($this->is_wp_ultimo_admin_page($screen)) {
+			wp_enqueue_script('wu-admin');
+		}
+
+		// Only load these scripts on specific pages where they're needed
+		if ($this->is_wp_ultimo_list_page($screen)) {
+			wp_enqueue_script('wu-ajax-list-table');
+		}
+
+		// Load Vue apps only on pages that need them
+		if ($this->is_wp_ultimo_vue_page($screen)) {
+			wp_enqueue_script('wu-vue-apps');
+		}
+
+		// Load wubox only when needed
+		if ($this->is_wp_ultimo_modal_page($screen)) {
+			wp_enqueue_script('wubox');
+		}
 	}
 
 	/**
@@ -381,5 +426,117 @@ class Scripts {
 		}
 
 		return $classes;
+	}
+
+	/**
+	 * Checks if the current screen is a WP Ultimo admin page.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param \WP_Screen $screen The current screen object.
+	 * @return bool
+	 */
+	private function is_wp_ultimo_admin_page($screen) {
+		// Check if the screen ID contains 'wp-ultimo' or if it's a WP Ultimo admin page
+		return (
+			strpos($screen->id, 'wp-ultimo') !== false ||
+			strpos($screen->id, 'wu-') !== false ||
+			(isset($_GET['page']) && strpos($_GET['page'], 'wu-') === 0)
+		);
+	}
+
+	/**
+	 * Checks if the current screen is a WP Ultimo list page that needs the list table scripts.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param \WP_Screen $screen The current screen object.
+	 * @return bool
+	 */
+	private function is_wp_ultimo_list_page($screen) {
+		// Pages that use list tables
+		$list_pages = array(
+			'wu-memberships',
+			'wu-products',
+			'wu-customers',
+			'wu-payments',
+			'wu-discount-codes',
+			'wu-domain-mappings',
+			'wu-sites',
+		);
+
+		return $this->is_wp_ultimo_admin_page($screen) &&
+			   isset($_GET['page']) &&
+			   in_array($_GET['page'], $list_pages);
+	}
+
+	/**
+	 * Checks if the current screen is a WP Ultimo page that needs Vue.js.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param \WP_Screen $screen The current screen object.
+	 * @return bool
+	 */
+	private function is_wp_ultimo_vue_page($screen) {
+		// Pages that use Vue.js
+		$vue_pages = array(
+			'wu-settings',
+			'wu-add-membership',
+			'wu-edit-membership',
+			'wu-add-product',
+			'wu-edit-product',
+			'wu-add-customer',
+			'wu-edit-customer',
+			'wu-add-payment',
+			'wu-edit-payment',
+			'wu-add-discount-code',
+			'wu-edit-discount-code',
+			'wu-add-domain-mapping',
+			'wu-edit-domain-mapping',
+			'wu-add-site',
+			'wu-edit-site',
+			'wu-checkout-form',
+		);
+
+		return $this->is_wp_ultimo_admin_page($screen) &&
+			   isset($_GET['page']) &&
+			   (in_array($_GET['page'], $vue_pages) || strpos($_GET['page'], 'wu-checkout') === 0);
+	}
+
+	/**
+	 * Checks if the current screen is a WP Ultimo page that needs modal functionality.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param \WP_Screen $screen The current screen object.
+	 * @return bool
+	 */
+	private function is_wp_ultimo_modal_page($screen) {
+		// Most WP Ultimo admin pages need the modal functionality
+		return $this->is_wp_ultimo_admin_page($screen);
+	}
+
+	/**
+	 * Checks if the current screen is a WP Ultimo page that needs country flags.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param \WP_Screen $screen The current screen object.
+	 * @return bool
+	 */
+	private function is_wp_ultimo_flags_page($screen) {
+		// Pages that use country flags
+		$flags_pages = array(
+			'wu-settings',
+			'wu-add-customer',
+			'wu-edit-customer',
+			'wu-add-payment',
+			'wu-edit-payment',
+		);
+
+		return $this->is_wp_ultimo_admin_page($screen) &&
+			   isset($_GET['page']) &&
+			   in_array($_GET['page'], $flags_pages);
 	}
 }

--- a/inc/functions/assets.php
+++ b/inc/functions/assets.php
@@ -22,7 +22,16 @@ defined('ABSPATH') || exit;
 function wu_get_asset($asset, $assets_dir = 'img', $base_dir = 'assets') {
 
 	if ( ! defined('SCRIPT_DEBUG') || ! SCRIPT_DEBUG) {
-		$asset = preg_replace('/(?<!\.min)(\.js|\.css)/', '.min$1', $asset);
+		// Create the minified filename
+		$minified_asset = preg_replace('/(?<!\.min)(\.js|\.css)/', '.min$1', $asset);
+		
+		// Check if the minified file exists
+		$minified_path = WP_ULTIMO_PLUGIN_DIR . "$base_dir/$assets_dir/$minified_asset";
+		
+		// Only use the minified version if it exists
+		if (file_exists($minified_path)) {
+			$asset = $minified_asset;
+		}
 	}
 
 	return wu_url("$base_dir/$assets_dir/$asset");


### PR DESCRIPTION
For consideration, or feedback:

# Performance Optimization: Conditional Asset Loading

## Description
This PR implements conditional loading of scripts and styles to improve performance by reducing unnecessary asset loading. The optimization focuses on loading scripts and styles only when they are needed, rather than on every admin page.

## Changes Made
1. Added methods to check if the current screen is a WP Ultimo admin page
2. Added methods to check if specific scripts/styles are needed on the current page:
   - `is_wp_ultimo_list_page()` - For pages that need list table scripts
   - `is_wp_ultimo_vue_page()` - For pages that need Vue.js
   - `is_wp_ultimo_modal_page()` - For pages that need modal functionality
   - `is_wp_ultimo_flags_page()` - For pages that need country flags
3. Modified `enqueue_default_admin_styles()` and `enqueue_default_admin_scripts()` to conditionally load assets
4. Added file existence check for minified assets in `wu_get_asset()` function

## Benefits
- Reduced page load time by loading only necessary scripts and styles
- Decreased memory usage on non-WP Ultimo admin pages
- Improved overall admin experience by reducing potential conflicts with other plugins
- Better performance for sites with many plugins

## Testing
1. Verify that WP Ultimo admin pages still function correctly
2. Check that scripts and styles are loaded only on relevant pages
3. Confirm that minified assets are used when available

## Note on Previous PR
This PR is a focused version of the performance optimizations from PR #39. Based on feedback from @superdav42, we've removed the database query caching portion as BerlinDB already handles that efficiently. This PR focuses solely on the conditional asset loading improvements.
