### PR TITLE
Add GitHub workflow for automatic plugin releases

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,6 +2,43 @@
 
 This directory contains GitHub Actions workflows for automating various tasks in the repository.
 
+## Release Workflow
+
+The `release.yml` workflow automatically builds and releases the plugin when a new tag is pushed to the repository.
+
+### How it works
+
+1. When a new tag is pushed (in the format `v*.*.*`), the workflow is triggered
+2. The workflow checks out the code, sets up PHP and Node.js
+3. It verifies that the version in the tag matches the version in the plugin files
+4. It runs the build process using `npm run build`
+5. It creates a ZIP file of the plugin
+6. It creates a GitHub release with the ZIP file attached
+
+### Usage
+
+To create a new release:
+
+1. Update the version number in:
+   - `wp-multisite-waas.php` (the `Version:` header)
+   - `readme.txt` (the `Stable tag:` field)
+   - `package.json` (the `version` field)
+
+2. Commit these changes
+
+3. Create and push a new tag:
+   ```
+   git tag v1.2.3
+   git push origin v1.2.3
+   ```
+
+4. The workflow will automatically create a release with the built plugin
+
+### Requirements
+
+- The repository must have a `package.json` file with a `build` script
+- The plugin must have consistent version numbers across all files
+
 ## Sync Wiki Workflow
 
 The `sync-wiki.yml` workflow automatically syncs the content of the `.wiki` directory to the GitHub wiki whenever changes are pushed to the main branch.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,8 +67,8 @@ jobs:
           files: |
             build/wp-multisite-waas-${{ env.VERSION }}.zip
           name: WP Multisite WaaS ${{ env.VERSION }}
-          draft: false
-          prerelease: false
+          draft: true
+          prerelease: true
           body: |
             # WP Multisite WaaS ${{ env.VERSION }}
             

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release WordPress Plugin
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    name: Build and Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          extensions: mbstring, intl, curl
+          tools: composer, wp-cli
+
+      - name: Get the version
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify version matches
+        run: |
+          WP_VERSION=$(grep -m 1 "Version: " wp-multisite-waas.php | awk -F' ' '{print $2}')
+          README_VERSION=$(grep -m 1 "Stable tag: " readme.txt | awk -F' ' '{print $3}')
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          
+          if [ "$WP_VERSION" != "${{ env.VERSION }}" ] || [ "$README_VERSION" != "${{ env.VERSION }}" ] || [ "$PKG_VERSION" != "${{ env.VERSION }}" ]; then
+            echo "Error: Version mismatch detected!"
+            echo "Tag version: ${{ env.VERSION }}"
+            echo "Plugin version: $WP_VERSION"
+            echo "readme.txt version: $README_VERSION"
+            echo "package.json version: $PKG_VERSION"
+            exit 1
+          fi
+          
+          echo "All version numbers match: ${{ env.VERSION }}"
+
+      - name: Run build process
+        run: npm run build
+
+      - name: Create ZIP file
+        run: |
+          mkdir -p build
+          zip -r build/wp-multisite-waas-${{ env.VERSION }}.zip . -x "*.git*" "node_modules/*" "tests/*" "build/*" "*.zip" "*.log"
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            build/wp-multisite-waas-${{ env.VERSION }}.zip
+          name: WP Multisite WaaS ${{ env.VERSION }}
+          draft: false
+          prerelease: false
+          body: |
+            # WP Multisite WaaS ${{ env.VERSION }}
+            
+            ## What's Changed
+            
+            For a complete list of changes, please refer to the [changelog](https://github.com/superdav42/wp-multisite-waas/blob/main/readme.txt).
+            
+            ## Installation
+            
+            1. Download the ZIP file from this release
+            2. Upload and activate the plugin in your WordPress Network installation
+            3. Follow the setup wizard to configure the plugin
+            
+            ## Notes
+            
+            - Compatible with WordPress 5.3+
+            - Requires PHP 7.4.30+
+            - Always backup your site before upgrading


### PR DESCRIPTION
# Add GitHub Workflow for Automatic Plugin Releases

## Description
This PR adds a GitHub Actions workflow that automatically builds and releases the plugin when a new tag is pushed to the repository. This simplifies the release process and ensures consistent builds.

## Changes Made
1. Added `.github/workflows/release.yml` with the release workflow configuration
2. Updated `.github/workflows/README.md` to include documentation about the release workflow

## How It Works
1. When a new tag is pushed (in the format `v*.*.*`), the workflow is triggered
2. The workflow checks out the code, sets up PHP and Node.js
3. It verifies that the version in the tag matches the version in the plugin files
4. It runs the build process using `npm run build`
5. It creates a ZIP file of the plugin
6. It creates a GitHub release with the ZIP file attached

## Usage
To create a new release:

1. Update the version number in:
   - `wp-multisite-waas.php` (the `Version:` header)
   - `readme.txt` (the `Stable tag:` field)
   - `package.json` (the `version` field)

2. Commit these changes

3. Create and push a new tag:
   ```
   git tag v1.2.3
   git push origin v1.2.3
   ```

4. The workflow will automatically create a release with the built plugin

## Note on Previous PR
This PR is a focused version of PR #26, which included many additional files and changes. Based on the discussion in PR #26, I've created this new PR with only the essential files needed for the GitHub workflow for automatic plugin releases.
