### PR TITLE
Update documentation links to GitHub wiki

### DIFF
--- a/.wiki/Closte-Integration.md
+++ b/.wiki/Closte-Integration.md
@@ -1,0 +1,67 @@
+# Closte Integration
+
+## Overview
+Closte is a managed WordPress hosting platform built on Google Cloud infrastructure. This integration enables automatic domain syncing and SSL certificate management between WP Multisite WaaS and Closte.
+
+## Features
+- Automatic domain syncing
+- SSL certificate management
+- Wildcard domain support
+- No configuration needed if running on Closte
+
+## Requirements
+The following constant must be defined in your `wp-config.php` file if you're using Closte:
+
+```php
+define('CLOSTE_CLIENT_API_KEY', 'your_api_key');
+```
+
+This constant is typically already defined if you're hosting on Closte.
+
+## Setup Instructions
+
+### 1. Verify Your Closte API Key
+
+If you're hosting on Closte, the `CLOSTE_CLIENT_API_KEY` constant should already be defined in your `wp-config.php` file. You can verify this by checking your `wp-config.php` file.
+
+### 2. Enable the Integration
+
+1. In your WordPress admin, go to WP Multisite WaaS > Settings
+2. Navigate to the "Domain Mapping" tab
+3. Scroll down to "Host Integrations"
+4. Enable the Closte integration
+5. Click "Save Changes"
+
+## How It Works
+
+When a domain is mapped in WP Multisite WaaS:
+
+1. The integration sends a request to Closte's API to add the domain to your application
+2. Closte automatically handles SSL certificate provisioning
+3. When a domain mapping is removed, the integration will remove the domain from Closte
+
+The integration also works with the DNS check interval setting in WP Multisite WaaS, allowing you to configure how frequently the system checks for DNS propagation and SSL certificate issuance.
+
+## Domain Record Creation
+
+This integration ensures that when a site is created or duplicated, a domain record is automatically created. This is particularly important for the Closte integration, as the domain record creation triggers the Closte API to create the domain and SSL certificate.
+
+## Troubleshooting
+
+### API Connection Issues
+- Verify that your Closte API key is correct
+- Ensure that your Closte account has the necessary permissions
+
+### SSL Certificate Issues
+- Closte may take some time to issue SSL certificates (usually 5-10 minutes)
+- Verify that your domains are properly pointing to your Closte server's IP address
+- Check the DNS records for your domain to ensure they're correctly configured
+
+### Domain Not Added
+- Check the WP Multisite WaaS logs for any error messages
+- Verify that the domain is not already added to Closte
+- Ensure that your domain's DNS records are properly configured
+
+### DNS Check Interval
+- If SSL certificates are taking too long to issue, you can adjust the DNS check interval in the Domain Mapping settings
+- The default interval is 300 seconds (5 minutes), but you can set it as low as 10 seconds for faster checking during testing

--- a/.wiki/Cloudflare-Integration.md
+++ b/.wiki/Cloudflare-Integration.md
@@ -1,0 +1,92 @@
+# Cloudflare Integration
+
+## Overview
+Cloudflare is a leading content delivery network (CDN) and security provider that helps protect and accelerate websites. This integration enables automatic domain management between WP Multisite WaaS and Cloudflare, particularly for subdomain multisite installations.
+
+## Features
+- Automatic subdomain creation in Cloudflare
+- Proxied subdomain support
+- DNS record management
+- Enhanced DNS record display in the WP Multisite WaaS admin
+
+## Requirements
+The following constants must be defined in your `wp-config.php` file:
+
+```php
+define('WU_CLOUDFLARE_API_KEY', 'your_api_key');
+define('WU_CLOUDFLARE_ZONE_ID', 'your_zone_id');
+```
+
+## Setup Instructions
+
+### 1. Get Your Cloudflare API Key
+
+1. Log in to your Cloudflare dashboard
+2. Go to "My Profile" (click on your email in the top-right corner)
+3. Select "API Tokens" from the menu
+4. Create a new API token with the following permissions:
+   - Zone.Zone: Read
+   - Zone.DNS: Edit
+5. Copy your API token
+
+### 2. Get Your Zone ID
+
+1. In your Cloudflare dashboard, select the domain you want to use
+2. The Zone ID is visible in the "Overview" tab, in the right sidebar under "API"
+3. Copy the Zone ID
+
+### 3. Add Constants to wp-config.php
+
+Add the following constants to your `wp-config.php` file:
+
+```php
+define('WU_CLOUDFLARE_API_KEY', 'your_api_token');
+define('WU_CLOUDFLARE_ZONE_ID', 'your_zone_id');
+```
+
+### 4. Enable the Integration
+
+1. In your WordPress admin, go to WP Multisite WaaS > Settings
+2. Navigate to the "Domain Mapping" tab
+3. Scroll down to "Host Integrations"
+4. Enable the Cloudflare integration
+5. Click "Save Changes"
+
+## How It Works
+
+### Subdomain Management
+
+When a new site is created in a subdomain multisite installation:
+
+1. The integration sends a request to Cloudflare's API to add a CNAME record for the subdomain
+2. The subdomain is configured to be proxied through Cloudflare by default (this can be changed with filters)
+3. When a site is deleted, the integration will remove the subdomain from Cloudflare
+
+### DNS Record Display
+
+The integration enhances the DNS record display in the WP Multisite WaaS admin by:
+
+1. Fetching DNS records directly from Cloudflare
+2. Displaying whether records are proxied or not
+3. Showing additional information about the DNS records
+
+## Important Notes
+
+As of Cloudflare's recent updates, wildcard proxying is now available for all customers. This means that the Cloudflare integration is less critical for subdomain multisite installations than it used to be, as you can simply set up a wildcard DNS record in Cloudflare.
+
+## Troubleshooting
+
+### API Connection Issues
+- Verify that your API token is correct and has the necessary permissions
+- Check that your Zone ID is correct
+- Ensure that your Cloudflare account has the necessary permissions
+
+### Subdomain Not Added
+- Check the WP Multisite WaaS logs for any error messages
+- Verify that the subdomain is not already added to Cloudflare
+- Ensure that your Cloudflare plan supports the number of DNS records you're creating
+
+### Proxying Issues
+- If you don't want subdomains to be proxied, you can use the `wu_cloudflare_should_proxy` filter
+- Some features may not work correctly when proxied (e.g., certain WordPress admin functions)
+- Consider using Cloudflare's Page Rules to bypass the cache for admin pages

--- a/.wiki/Cloudways-Integration.md
+++ b/.wiki/Cloudways-Integration.md
@@ -1,0 +1,114 @@
+# Cloudways Integration
+
+## Overview
+Cloudways is a managed cloud hosting platform that allows you to deploy WordPress sites on various cloud providers like DigitalOcean, AWS, Google Cloud, and more. This integration enables automatic domain syncing and SSL certificate management between WP Multisite WaaS and Cloudways.
+
+## Features
+- Automatic domain syncing
+- SSL certificate management
+- Support for extra domains
+- DNS validation for SSL certificates
+
+## Requirements
+The following constants must be defined in your `wp-config.php` file:
+
+```php
+define('WU_CLOUDWAYS_EMAIL', 'your_cloudways_email');
+define('WU_CLOUDWAYS_API_KEY', 'your_api_key');
+define('WU_CLOUDWAYS_SERVER_ID', 'your_server_id');
+define('WU_CLOUDWAYS_APP_ID', 'your_app_id');
+```
+
+Optionally, you can also define:
+
+```php
+define('WU_CLOUDWAYS_EXTRA_DOMAINS', 'comma,separated,list,of,domains');
+```
+
+## Setup Instructions
+
+### 1. Get Your Cloudways API Credentials
+
+1. Log in to your Cloudways dashboard
+2. Go to "Account" > "API Keys"
+3. Generate an API key if you don't already have one
+4. Copy your email and API key
+
+### 2. Get Your Server and Application IDs
+
+1. In your Cloudways dashboard, go to "Servers"
+2. Select the server where your WordPress multisite is hosted
+3. The Server ID is visible in the URL: `https://platform.cloudways.com/server/{SERVER_ID}`
+4. Go to "Applications" and select your WordPress application
+5. The App ID is visible in the URL: `https://platform.cloudways.com/server/{SERVER_ID}/application/{APP_ID}`
+
+### 3. Add Constants to wp-config.php
+
+Add the following constants to your `wp-config.php` file:
+
+```php
+define('WU_CLOUDWAYS_EMAIL', 'your_cloudways_email');
+define('WU_CLOUDWAYS_API_KEY', 'your_api_key');
+define('WU_CLOUDWAYS_SERVER_ID', 'your_server_id');
+define('WU_CLOUDWAYS_APP_ID', 'your_app_id');
+```
+
+If you have additional domains that should always be included:
+
+```php
+define('WU_CLOUDWAYS_EXTRA_DOMAINS', 'domain1.com,domain2.com,*.wildcard.com');
+```
+
+### 4. Enable the Integration
+
+1. In your WordPress admin, go to WP Multisite WaaS > Settings
+2. Navigate to the "Domain Mapping" tab
+3. Scroll down to "Host Integrations"
+4. Enable the Cloudways integration
+5. Click "Save Changes"
+
+## How It Works
+
+### Domain Syncing
+
+When a domain is mapped in WP Multisite WaaS:
+
+1. The integration retrieves all currently mapped domains
+2. It adds the new domain to the list (along with a www version if applicable)
+3. It sends the complete list to Cloudways via the API
+4. Cloudways updates the domain aliases for your application
+
+Note: The Cloudways API requires sending the complete list of domains each time, not just adding or removing individual domains.
+
+### SSL Certificate Management
+
+After domains are synced:
+
+1. The integration checks which domains have valid DNS records pointing to your server
+2. It sends a request to Cloudways to install Let's Encrypt SSL certificates for those domains
+3. Cloudways handles the SSL certificate issuance and installation
+
+## Extra Domains
+
+The `WU_CLOUDWAYS_EXTRA_DOMAINS` constant allows you to specify additional domains that should always be included when syncing with Cloudways. This is useful for:
+
+- Domains that are not managed by WP Multisite WaaS
+- Wildcard domains (e.g., `*.example.com`)
+- Development or staging domains
+
+## Troubleshooting
+
+### API Connection Issues
+- Verify that your email and API key are correct
+- Check that your server and application IDs are correct
+- Ensure that your Cloudways account has the necessary permissions
+
+### SSL Certificate Issues
+- Cloudways requires that domains have valid DNS records pointing to your server before issuing SSL certificates
+- The integration validates DNS records before requesting SSL certificates
+- If SSL certificates are not being issued, check that your domains are properly pointing to your server's IP address
+
+### Domain Not Added
+- Check the WP Multisite WaaS logs for any error messages
+- Verify that the domain is not already added to Cloudways
+- Ensure that your Cloudways plan supports the number of domains you're adding

--- a/.wiki/GridPane-Integration.md
+++ b/.wiki/GridPane-Integration.md
@@ -1,0 +1,86 @@
+# GridPane Integration
+
+## Overview
+GridPane is a specialized WordPress hosting control panel built for serious WordPress professionals. This integration enables automatic domain syncing and SSL certificate management between WP Multisite WaaS and GridPane.
+
+## Features
+- Automatic domain syncing
+- SSL certificate management
+- Automatic configuration of SUNRISE constant
+
+## Requirements
+The following constants must be defined in your `wp-config.php` file:
+
+```php
+define('WU_GRIDPANE', true);
+define('WU_GRIDPANE_API_KEY', 'your_api_key');
+define('WU_GRIDPANE_SERVER_ID', 'your_server_id');
+define('WU_GRIDPANE_APP_ID', 'your_app_id');
+```
+
+## Setup Instructions
+
+### 1. Get Your GridPane API Credentials
+
+1. Log in to your GridPane dashboard
+2. Go to "Settings" > "API"
+3. Generate an API key if you don't already have one
+4. Copy your API key
+
+### 2. Get Your Server and Site IDs
+
+1. In your GridPane dashboard, go to "Servers"
+2. Select the server where your WordPress multisite is hosted
+3. Note the Server ID (visible in the URL or on the server details page)
+4. Go to "Sites" and select your WordPress site
+5. Note the Site ID (visible in the URL or on the site details page)
+
+### 3. Add Constants to wp-config.php
+
+Add the following constants to your `wp-config.php` file:
+
+```php
+define('WU_GRIDPANE', true);
+define('WU_GRIDPANE_API_KEY', 'your_api_key');
+define('WU_GRIDPANE_SERVER_ID', 'your_server_id');
+define('WU_GRIDPANE_APP_ID', 'your_site_id');
+```
+
+### 4. Enable the Integration
+
+1. In your WordPress admin, go to WP Multisite WaaS > Settings
+2. Navigate to the "Domain Mapping" tab
+3. Scroll down to "Host Integrations"
+4. Enable the GridPane integration
+5. Click "Save Changes"
+
+## How It Works
+
+When a domain is mapped in WP Multisite WaaS:
+
+1. The integration sends a request to GridPane's API to add the domain to your site
+2. GridPane automatically handles SSL certificate provisioning
+3. When a domain mapping is removed, the integration will remove the domain from GridPane
+
+The integration also automatically handles the SUNRISE constant in your wp-config.php file, which is required for domain mapping to work correctly.
+
+## SUNRISE Constant Management
+
+One unique feature of the GridPane integration is that it automatically reverts the SUNRISE constant in wp-config.php to prevent conflicts with GridPane's own domain mapping system. This ensures that both systems can work together without issues.
+
+## Troubleshooting
+
+### API Connection Issues
+- Verify that your API key is correct
+- Check that your server and site IDs are correct
+- Ensure that your GridPane account has the necessary permissions
+
+### SSL Certificate Issues
+- GridPane may take some time to issue SSL certificates
+- Verify that your domains are properly pointing to your server's IP address
+- Check the GridPane SSL settings for your site
+
+### Domain Not Added
+- Check the WP Multisite WaaS logs for any error messages
+- Verify that the domain is not already added to GridPane
+- Ensure that your domain's DNS records are properly configured

--- a/.wiki/Home.md
+++ b/.wiki/Home.md
@@ -26,6 +26,19 @@ Configure your WP Multisite WaaS network.
 - [Checkout Forms](checkout-forms) - Customize your checkout forms
 - [Creating Products](creating-your-first-subscription-product-v2) - Set up subscription products
 
+### Host Provider Integrations
+Integrate with various hosting providers for domain management.
+
+- [Closte Integration](Closte-Integration) - Automatic domain syncing with Closte hosting
+- [Cloudflare Integration](Cloudflare-Integration) - DNS management with Cloudflare
+- [Cloudways Integration](Cloudways-Integration) - Domain syncing with Cloudways hosting
+- [cPanel Integration](cPanel-Integration) - Domain management with cPanel
+- [GridPane Integration](GridPane-Integration) - Domain syncing with GridPane
+- [RunCloud Integration](Runcloud-Integration) - Domain syncing with RunCloud
+- [ServerPilot Integration](ServerPilot-Integration) - Domain syncing with ServerPilot
+- [WP Engine Integration](WP-Engine-Integration) - Domain management with WP Engine
+- [WPMU DEV Integration](WPMU-DEV-Integration) - Domain syncing with WPMU DEV hosting
+
 ### Payment Gateways
 Set up payment processing for your network.
 
@@ -49,3 +62,17 @@ Browse all documentation using the sidebar navigation on the right. The document
 - **Troubleshooting** - Solve common issues
 - **Migration & Updates** - Migrate from v1 and update your installation
 - **Miscellaneous** - Other useful information
+
+## Host Provider Integrations
+
+WP Multisite WaaS integrates with various hosting providers to automate domain management and SSL certificate issuance:
+
+- [Closte Integration](Closte-Integration) - Automatic domain syncing with Closte hosting
+- [Cloudflare Integration](Cloudflare-Integration) - DNS management with Cloudflare
+- [Cloudways Integration](Cloudways-Integration) - Domain syncing with Cloudways hosting
+- [cPanel Integration](cPanel-Integration) - Domain management with cPanel
+- [GridPane Integration](GridPane-Integration) - Domain syncing with GridPane
+- [RunCloud Integration](Runcloud-Integration) - Domain syncing with RunCloud
+- [ServerPilot Integration](ServerPilot-Integration) - Domain syncing with ServerPilot
+- [WP Engine Integration](WP-Engine-Integration) - Domain management with WP Engine
+- [WPMU DEV Integration](WPMU-DEV-Integration) - Domain syncing with WPMU DEV hosting

--- a/.wiki/Runcloud-Integration.md
+++ b/.wiki/Runcloud-Integration.md
@@ -1,0 +1,83 @@
+# RunCloud Integration
+
+## Overview
+RunCloud is a cloud-based server management platform that allows you to easily deploy and manage web applications on your own cloud servers. This integration enables automatic domain syncing and SSL certificate management between WP Multisite WaaS and RunCloud.
+
+## Features
+- Automatic domain syncing
+- SSL certificate management
+- Domain removal when mappings are deleted
+
+## Requirements
+The following constants must be defined in your `wp-config.php` file:
+
+```php
+define('WU_RUNCLOUD_API_KEY', 'your_api_key');
+define('WU_RUNCLOUD_API_SECRET', 'your_api_secret');
+define('WU_RUNCLOUD_SERVER_ID', 'your_server_id');
+define('WU_RUNCLOUD_APP_ID', 'your_app_id');
+```
+
+## Setup Instructions
+
+### 1. Get Your RunCloud API Credentials
+
+1. Log in to your RunCloud dashboard
+2. Go to "User Profile" (click on your profile picture in the top-right corner)
+3. Select "API" from the menu
+4. Click "Generate API Key" if you don't already have one
+5. Copy your API Key and API Secret
+
+### 2. Get Your Server and App IDs
+
+1. In your RunCloud dashboard, go to "Servers"
+2. Select the server where your WordPress multisite is hosted
+3. The Server ID is visible in the URL: `https://manage.runcloud.io/servers/{SERVER_ID}`
+4. Go to "Web Applications" and select your WordPress application
+5. The App ID is visible in the URL: `https://manage.runcloud.io/servers/{SERVER_ID}/apps/{APP_ID}`
+
+### 3. Add Constants to wp-config.php
+
+Add the following constants to your `wp-config.php` file:
+
+```php
+define('WU_RUNCLOUD_API_KEY', 'your_api_key');
+define('WU_RUNCLOUD_API_SECRET', 'your_api_secret');
+define('WU_RUNCLOUD_SERVER_ID', 'your_server_id');
+define('WU_RUNCLOUD_APP_ID', 'your_app_id');
+```
+
+### 4. Enable the Integration
+
+1. In your WordPress admin, go to WP Multisite WaaS > Settings
+2. Navigate to the "Domain Mapping" tab
+3. Scroll down to "Host Integrations"
+4. Enable the RunCloud integration
+5. Click "Save Changes"
+
+## How It Works
+
+When a domain is mapped in WP Multisite WaaS:
+
+1. The integration sends a request to RunCloud's API to add the domain to your application
+2. If the domain is successfully added, the integration will also redeploy SSL certificates
+3. When a domain mapping is removed, the integration will remove the domain from RunCloud
+
+For subdomain installations, the integration will automatically handle the creation of subdomains in RunCloud when new sites are added to your network.
+
+## Troubleshooting
+
+### API Connection Issues
+- Verify that your API credentials are correct
+- Check that your server and app IDs are correct
+- Ensure that your RunCloud account has the necessary permissions
+
+### SSL Certificate Issues
+- RunCloud may take some time to issue SSL certificates
+- Verify that your domains are properly pointing to your server's IP address
+- Check the RunCloud SSL settings for your application
+
+### Domain Not Added
+- Check the WP Multisite WaaS logs for any error messages
+- Verify that the domain is not already added to RunCloud
+- Ensure that your RunCloud plan supports multiple domains

--- a/.wiki/ServerPilot-Integration.md
+++ b/.wiki/ServerPilot-Integration.md
@@ -1,0 +1,95 @@
+# ServerPilot Integration
+
+## Overview
+ServerPilot is a cloud service for hosting WordPress and other PHP websites on servers at DigitalOcean, Amazon, Google, or any other server provider. This integration enables automatic domain syncing and SSL certificate management between WP Multisite WaaS and ServerPilot.
+
+## Features
+- Automatic domain syncing
+- SSL certificate management with Let's Encrypt
+- Automatic SSL renewal
+
+## Requirements
+The following constants must be defined in your `wp-config.php` file:
+
+```php
+define('WU_SERVER_PILOT_CLIENT_ID', 'your_client_id');
+define('WU_SERVER_PILOT_API_KEY', 'your_api_key');
+define('WU_SERVER_PILOT_APP_ID', 'your_app_id');
+```
+
+## Setup Instructions
+
+### 1. Get Your ServerPilot API Credentials
+
+1. Log in to your ServerPilot dashboard
+2. Go to "Account" > "API"
+3. Create a new API key if you don't already have one
+4. Copy your Client ID and API Key
+
+### 2. Get Your App ID
+
+1. In your ServerPilot dashboard, go to "Apps"
+2. Select the app where your WordPress multisite is hosted
+3. The App ID is visible in the URL: `https://manage.serverpilot.io/apps/{APP_ID}`
+
+### 3. Add Constants to wp-config.php
+
+Add the following constants to your `wp-config.php` file:
+
+```php
+define('WU_SERVER_PILOT_CLIENT_ID', 'your_client_id');
+define('WU_SERVER_PILOT_API_KEY', 'your_api_key');
+define('WU_SERVER_PILOT_APP_ID', 'your_app_id');
+```
+
+### 4. Enable the Integration
+
+1. In your WordPress admin, go to WP Multisite WaaS > Settings
+2. Navigate to the "Domain Mapping" tab
+3. Scroll down to "Host Integrations"
+4. Enable the ServerPilot integration
+5. Click "Save Changes"
+
+## How It Works
+
+### Domain Syncing
+
+When a domain is mapped in WP Multisite WaaS:
+
+1. The integration retrieves the current list of domains from ServerPilot
+2. It adds the new domain to the list (along with a www version if applicable)
+3. It sends the updated list to ServerPilot via the API
+4. ServerPilot updates the domain list for your application
+
+### SSL Certificate Management
+
+After domains are synced:
+
+1. The integration automatically enables AutoSSL for your application
+2. ServerPilot handles the SSL certificate issuance and installation using Let's Encrypt
+3. ServerPilot also handles automatic renewal of SSL certificates
+
+## SSL Certificate Verification
+
+The integration is configured to increase the number of SSL certificate verification attempts for ServerPilot, as it may take some time for ServerPilot to issue and install SSL certificates. By default, it will try up to 5 times, but this can be adjusted using filters.
+
+## Troubleshooting
+
+### API Connection Issues
+- Verify that your Client ID and API Key are correct
+- Check that your App ID is correct
+- Ensure that your ServerPilot account has the necessary permissions
+
+### SSL Certificate Issues
+- ServerPilot requires that domains have valid DNS records pointing to your server before issuing SSL certificates
+- If SSL certificates are not being issued, check that your domains are properly pointing to your server's IP address
+- It may take some time for ServerPilot to issue and install SSL certificates (usually 5-15 minutes)
+
+### Domain Not Added
+- Check the WP Multisite WaaS logs for any error messages
+- Verify that the domain is not already added to ServerPilot
+- Ensure that your ServerPilot plan supports the number of domains you're adding
+
+### Domain Removal
+- Currently, the ServerPilot API does not provide a way to remove individual domains
+- When a domain mapping is removed in WP Multisite WaaS, the integration will update the domain list in ServerPilot to exclude the removed domain

--- a/.wiki/WP-Engine-Integration.md
+++ b/.wiki/WP-Engine-Integration.md
@@ -1,0 +1,81 @@
+# WP Engine Integration
+
+## Overview
+WP Engine is a premium managed WordPress hosting platform that provides optimized performance, security, and scalability for WordPress sites. This integration enables automatic domain syncing between WP Multisite WaaS and WP Engine.
+
+## Features
+- Automatic domain syncing
+- Subdomain support for multisite installations
+- Seamless integration with WP Engine's existing systems
+
+## Requirements
+The integration automatically detects if you're hosting on WP Engine and uses the built-in WP Engine API. No additional configuration is required if the WP Engine plugin is active and properly configured.
+
+However, if you need to manually configure the integration, you can define one of these constants in your `wp-config.php` file:
+
+```php
+define('WPE_APIKEY', 'your_api_key'); // Preferred method
+// OR
+define('WPE_API', 'your_api_key'); // Alternative method
+```
+
+## Setup Instructions
+
+### 1. Verify WP Engine Plugin
+
+If you're hosting on WP Engine, the WP Engine plugin should already be installed and activated. Verify that:
+
+1. The WP Engine plugin is active
+2. The file `wp-content/mu-plugins/wpengine-common/class-wpeapi.php` exists
+
+### 2. Enable the Integration
+
+1. In your WordPress admin, go to WP Multisite WaaS > Settings
+2. Navigate to the "Domain Mapping" tab
+3. Scroll down to "Host Integrations"
+4. Enable the WP Engine integration
+5. Click "Save Changes"
+
+## How It Works
+
+### Domain Syncing
+
+When a domain is mapped in WP Multisite WaaS:
+
+1. The integration uses the WP Engine API to add the domain to your WP Engine installation
+2. WP Engine handles the domain configuration and SSL certificate issuance
+3. When a domain mapping is removed, the integration will remove the domain from WP Engine
+
+### Subdomain Support
+
+For subdomain multisite installations:
+
+1. The integration adds each subdomain to WP Engine when a new site is created
+2. WP Engine handles the subdomain configuration
+3. When a site is deleted, the integration will remove the subdomain from WP Engine
+
+## Important Notes
+
+### Wildcard Domains
+
+For subdomain multisite installations, it's recommended to contact WP Engine support to request a wildcard domain configuration. This allows all subdomains to work automatically without needing to add each one individually.
+
+### SSL Certificates
+
+WP Engine automatically handles SSL certificate issuance and renewal for all domains added through this integration. No additional configuration is required.
+
+## Troubleshooting
+
+### API Connection Issues
+- Verify that the WP Engine plugin is active and properly configured
+- If you've manually defined the API key, check that it's correct
+- Contact WP Engine support if you're having trouble with the API
+
+### Domain Not Added
+- Check the WP Multisite WaaS logs for any error messages
+- Verify that the domain is not already added to WP Engine
+- Ensure that your WP Engine plan supports the number of domains you're adding
+
+### Subdomain Issues
+- If subdomains are not working, contact WP Engine support to request a wildcard domain configuration
+- Verify that your DNS settings are correctly configured for the main domain and subdomains

--- a/.wiki/WPMU-DEV-Integration.md
+++ b/.wiki/WPMU-DEV-Integration.md
@@ -1,0 +1,72 @@
+# WPMU DEV Integration
+
+## Overview
+WPMU DEV is a comprehensive WordPress platform that offers hosting, plugins, and services for WordPress sites. This integration enables automatic domain syncing and SSL certificate management between WP Multisite WaaS and WPMU DEV hosting.
+
+## Features
+- Automatic domain syncing
+- SSL certificate management
+- Extended SSL certificate verification attempts
+
+## Requirements
+The integration automatically detects if you're hosting on WPMU DEV and uses the built-in API. No additional configuration is required if you're hosting on WPMU DEV.
+
+The integration checks for the presence of the `WPMUDEV_HOSTING_SITE_ID` constant, which is automatically defined when hosting on WPMU DEV.
+
+## Setup Instructions
+
+### 1. Verify WPMU DEV Hosting
+
+If you're hosting on WPMU DEV, the necessary constants should already be defined. Verify that:
+
+1. The `WPMUDEV_HOSTING_SITE_ID` constant is defined in your environment
+2. You have an active WPMU DEV membership with API access
+
+### 2. Enable the Integration
+
+1. In your WordPress admin, go to WP Multisite WaaS > Settings
+2. Navigate to the "Domain Mapping" tab
+3. Scroll down to "Host Integrations"
+4. Enable the WPMU DEV integration
+5. Click "Save Changes"
+
+## How It Works
+
+### Domain Syncing
+
+When a domain is mapped in WP Multisite WaaS:
+
+1. The integration uses the WPMU DEV API to add the domain to your hosting account
+2. It also adds the www version of the domain automatically
+3. WPMU DEV handles the domain configuration and SSL certificate issuance
+
+### SSL Certificate Management
+
+The integration is configured to increase the number of SSL certificate verification attempts for WPMU DEV hosting, as it may take some time for SSL certificates to be issued and installed. By default, it will try up to 10 times for SSL certificate verification, compared to the standard 5 attempts.
+
+## Important Notes
+
+### Domain Removal
+
+Currently, the WPMU DEV API does not provide a way to remove domains. When a domain mapping is removed in WP Multisite WaaS, the domain will remain in your WPMU DEV hosting account. You will need to manually remove it from the WPMU DEV hosting dashboard if necessary.
+
+### API Authentication
+
+The integration uses the WPMU DEV API key that is stored in your WordPress database as the `wpmudev_apikey` option. This is automatically set up when you connect your site to WPMU DEV.
+
+## Troubleshooting
+
+### API Connection Issues
+- Verify that your site is properly connected to WPMU DEV
+- Check that the `wpmudev_apikey` option is set in your WordPress database
+- Ensure that your WPMU DEV membership is active
+
+### SSL Certificate Issues
+- WPMU DEV may take some time to issue SSL certificates (usually 5-15 minutes)
+- The integration is configured to check up to 10 times for SSL certificates
+- If SSL certificates are still not being issued after multiple attempts, contact WPMU DEV support
+
+### Domain Not Added
+- Check the WP Multisite WaaS logs for any error messages
+- Verify that the domain is not already added to WPMU DEV
+- Ensure that your WPMU DEV hosting plan supports the number of domains you're adding

--- a/.wiki/_Sidebar.md
+++ b/.wiki/_Sidebar.md
@@ -36,6 +36,17 @@
 - [How to configure domain mapping (v1)](how-to-configure-domain-mapping-v1)
 - [Setting the Sunrise constant to true on Closte](setting-the-sunrise-constant-to-true-on-closte)
 
+## Host Provider Integrations
+- [Closte Integration](Closte-Integration)
+- [Cloudflare Integration](Cloudflare-Integration)
+- [Cloudways Integration](Cloudways-Integration)
+- [cPanel Integration](cPanel-Integration)
+- [GridPane Integration](GridPane-Integration)
+- [RunCloud Integration](Runcloud-Integration)
+- [ServerPilot Integration](ServerPilot-Integration)
+- [WP Engine Integration](WP-Engine-Integration)
+- [WPMU DEV Integration](WPMU-DEV-Integration)
+
 ## Payment Gateways
 - [Setting Up The Stripe Gateway (v2)](setting-up-the-stripe-gateway-v2)
 - [Setting Up The PayPal Gateway (v2)](setting-up-the-paypal-gateway-v2)

--- a/.wiki/cPanel-Integration.md
+++ b/.wiki/cPanel-Integration.md
@@ -1,0 +1,100 @@
+# cPanel Integration
+
+## Overview
+cPanel is one of the most popular web hosting control panels used by many shared and dedicated hosting providers. This integration enables automatic domain syncing between WP Multisite WaaS and cPanel, allowing you to automatically add domain aliases and subdomains to your cPanel account.
+
+## Features
+- Automatic addon domain creation in cPanel
+- Automatic subdomain creation in cPanel (for subdomain multisite installations)
+- Domain removal when mappings are deleted
+
+## Requirements
+The following constants must be defined in your `wp-config.php` file:
+
+```php
+define('WU_CPANEL_USERNAME', 'your_cpanel_username');
+define('WU_CPANEL_PASSWORD', 'your_cpanel_password');
+define('WU_CPANEL_HOST', 'your_cpanel_host');
+```
+
+Optionally, you can also define:
+
+```php
+define('WU_CPANEL_PORT', 2083); // Default is 2083
+define('WU_CPANEL_ROOT_DIR', '/public_html'); // Default is /public_html
+```
+
+## Setup Instructions
+
+### 1. Get Your cPanel Credentials
+
+1. Obtain your cPanel username and password from your hosting provider
+2. Determine your cPanel host (usually `cpanel.yourdomain.com` or `yourdomain.com:2083`)
+
+### 2. Add Constants to wp-config.php
+
+Add the following constants to your `wp-config.php` file:
+
+```php
+define('WU_CPANEL_USERNAME', 'your_cpanel_username');
+define('WU_CPANEL_PASSWORD', 'your_cpanel_password');
+define('WU_CPANEL_HOST', 'your_cpanel_host');
+```
+
+Optionally, you can customize the port and root directory:
+
+```php
+define('WU_CPANEL_PORT', 2083); // Change if your cPanel uses a different port
+define('WU_CPANEL_ROOT_DIR', '/public_html'); // Change if your document root is different
+```
+
+### 3. Enable the Integration
+
+1. In your WordPress admin, go to WP Multisite WaaS > Settings
+2. Navigate to the "Domain Mapping" tab
+3. Scroll down to "Host Integrations"
+4. Enable the cPanel integration
+5. Click "Save Changes"
+
+## How It Works
+
+### Addon Domains
+
+When a domain is mapped in WP Multisite WaaS:
+
+1. The integration sends a request to cPanel's API to add the domain as an addon domain
+2. The domain is configured to point to your root directory
+3. When a domain mapping is removed, the integration will remove the addon domain from cPanel
+
+### Subdomains
+
+For subdomain multisite installations, when a new site is created:
+
+1. The integration extracts the subdomain part from the full domain
+2. It sends a request to cPanel's API to add the subdomain
+3. The subdomain is configured to point to your root directory
+
+## Important Notes
+
+- The integration uses cPanel's API2 to communicate with your cPanel account
+- Your cPanel account must have permissions to add addon domains and subdomains
+- Some hosting providers may limit the number of addon domains or subdomains you can create
+- The integration does not handle DNS configuration; you still need to point your domains to your server's IP address
+
+## Troubleshooting
+
+### API Connection Issues
+- Verify that your cPanel username and password are correct
+- Check that your cPanel host is correct and accessible
+- Ensure that your cPanel account has the necessary permissions
+- Try using the full URL for the host (e.g., `https://cpanel.yourdomain.com`)
+
+### Domain Not Added
+- Check the WP Multisite WaaS logs for any error messages
+- Verify that the domain is not already added to cPanel
+- Ensure that your cPanel account has not reached its limit for addon domains or subdomains
+
+### SSL Certificate Issues
+- The integration does not handle SSL certificate issuance
+- You will need to use cPanel's SSL/TLS tools or AutoSSL feature to issue SSL certificates for your domains
+- Alternatively, you can use a service like Let's Encrypt with cPanel's AutoSSL

--- a/inc/checkout/signup-fields/class-signup-field-order-bump.php
+++ b/inc/checkout/signup-fields/class-signup-field-order-bump.php
@@ -219,7 +219,7 @@ class Signup_Field_Order_Bump extends Base_Signup_Field {
 		// 'order'           => 99,
 		// 'wrapper_classes' => 'sm:wu-p-0 sm:wu-block',
 		// 'classes'         => '',
-		// 'desc'            => sprintf('<div class="wu-p-4 wu-bg-blue-100 wu-text-grey-600">%s</div>', __('Want to add customized order bump templates?<br><a target="_blank" class="wu-no-underline" href="https://help.wpultimo.com/article/343-customize-your-checkout-flow-using-field-templates">See how you can do that here</a>.', 'wp-multisite-waas')),
+		// 'desc'            => sprintf('<div class="wu-p-4 wu-bg-blue-100 wu-text-grey-600">%s</div>', __('Want to add customized order bump templates?<br><a target="_blank" class="wu-no-underline" href="https://github.com/superdav42/wp-multisite-waas/wiki/Customize-Checkout-Flow">See how you can do that here</a>.', 'wp-multisite-waas')),
 		// );
 
 		return $editor_fields;

--- a/inc/checkout/signup-fields/class-signup-field-order-summary.php
+++ b/inc/checkout/signup-fields/class-signup-field-order-summary.php
@@ -194,7 +194,7 @@ class Signup_Field_Order_Summary extends Base_Signup_Field {
 		// 'order'           => 99,
 		// 'wrapper_classes' => 'sm:wu-p-0 sm:wu-block',
 		// 'classes'         => '',
-		// 'desc'            => sprintf('<div class="wu-p-4 wu-bg-blue-100 wu-text-grey-600">%s</div>', __('Want to add customized order summary templates?<br><a target="_blank" class="wu-no-underline" href="https://help.wpultimo.com/article/343-customize-your-checkout-flow-using-field-templates">See how you can do that here</a>.', 'wp-multisite-waas')),
+		// 'desc'            => sprintf('<div class="wu-p-4 wu-bg-blue-100 wu-text-grey-600">%s</div>', __('Want to add customized order summary templates?<br><a target="_blank" class="wu-no-underline" href="https://github.com/superdav42/wp-multisite-waas/wiki/Customize-Checkout-Flow">See how you can do that here</a>.', 'wp-multisite-waas')),
 		// );
 
 		return $editor_fields;

--- a/inc/checkout/signup-fields/class-signup-field-pricing-table.php
+++ b/inc/checkout/signup-fields/class-signup-field-pricing-table.php
@@ -230,7 +230,7 @@ class Signup_Field_Pricing_Table extends Base_Signup_Field {
 		// 'order'           => 99,
 		// 'wrapper_classes' => 'sm:wu-p-0 sm:wu-block',
 		// 'classes'         => '',
-		// 'desc'            => sprintf('<div class="wu-p-4 wu-bg-blue-100 wu-text-grey-600">%s</div>', __('Want to add customized pricing table templates?<br><a target="_blank" class="wu-no-underline" href="https://help.wpultimo.com/article/343-customize-your-checkout-flow-using-field-templates">See how you can do that here</a>.', 'wp-multisite-waas')),
+		// 'desc'            => sprintf('<div class="wu-p-4 wu-bg-blue-100 wu-text-grey-600">%s</div>', __('Want to add customized pricing table templates?<br><a target="_blank" class="wu-no-underline" href="https://github.com/superdav42/wp-multisite-waas/wiki/Customize-Checkout-Flow">See how you can do that here</a>.', 'wp-multisite-waas')),
 		// );
 
 		return $editor_fields;

--- a/inc/checkout/signup-fields/class-signup-field-steps.php
+++ b/inc/checkout/signup-fields/class-signup-field-steps.php
@@ -180,7 +180,7 @@ class Signup_Field_Steps extends Base_Signup_Field {
 		// 'order'           => 99,
 		// 'wrapper_classes' => 'sm:wu-p-0 sm:wu-block',
 		// 'classes'         => '',
-		// 'desc'            => sprintf('<div class="wu-p-4 wu-bg-blue-100 wu-text-grey-600">%s</div>', __('Want to add customized steps templates?<br><a target="_blank" class="wu-no-underline" href="https://help.wpultimo.com/article/343-customize-your-checkout-flow-using-field-templates">See how you can do that here</a>.', 'wp-multisite-waas')),
+		// 'desc'            => sprintf('<div class="wu-p-4 wu-bg-blue-100 wu-text-grey-600">%s</div>', __('Want to add customized steps templates?<br><a target="_blank" class="wu-no-underline" href="https://github.com/superdav42/wp-multisite-waas/wiki/Customize-Checkout-Flow">See how you can do that here</a>.', 'wp-multisite-waas')),
 		// );
 
 		return $editor_fields;

--- a/inc/checkout/signup-fields/class-signup-field-template-selection.php
+++ b/inc/checkout/signup-fields/class-signup-field-template-selection.php
@@ -265,7 +265,7 @@ class Signup_Field_Template_Selection extends Base_Signup_Field {
 		// 'order'           => 99,
 		// 'wrapper_classes' => 'sm:wu-p-0 sm:wu-block',
 		// 'classes'         => '',
-		// 'desc'            => sprintf('<div class="wu-p-4 wu-bg-blue-100 wu-text-grey-600">%s</div>', __('Want to add customized template selection templates?<br><a target="_blank" class="wu-no-underline" href="https://help.wpultimo.com/article/343-customize-your-checkout-flow-using-field-templates">See how you can do that here</a>.', 'wp-multisite-waas')),
+		// 'desc'            => sprintf('<div class="wu-p-4 wu-bg-blue-100 wu-text-grey-600">%s</div>', __('Want to add customized template selection templates?<br><a target="_blank" class="wu-no-underline" href="https://github.com/superdav42/wp-multisite-waas/wiki/Customize-Checkout-Flow">See how you can do that here</a>.', 'wp-multisite-waas')),
 		// );
 
 		return $editor_fields;

--- a/inc/class-documentation.php
+++ b/inc/class-documentation.php
@@ -35,7 +35,7 @@ class Documentation {
 	 *
 	 * @var string
 	 */
-	protected $default_link = 'https://help.wpultimo.com/';
+	protected $default_link = 'https://github.com/superdav42/wp-multisite-waas/wiki';
 
 	/**
 	 * Set the default links.
@@ -48,40 +48,40 @@ class Documentation {
 		$links = [];
 
 		// WP Multisite WaaS Dashboard
-		$links['wp-ultimo'] = 'https://help.wpultimo.com/en/articles/4803213-understanding-the-wp-ultimo-dashboard';
+		$links['wp-ultimo'] = 'https://github.com/superdav42/wp-multisite-waas/wiki';
 
 		// Settings Page
-		$links['wp-ultimo-settings'] = 'https://help.wpultimo.com';
+		$links['wp-ultimo-settings'] = 'https://github.com/superdav42/wp-multisite-waas/wiki';
 
 		// Checkout Pages
-		$links['wp-ultimo-checkout-forms']         = 'https://help.wpultimo.com/en/articles/4803465-checkout-forms';
-		$links['wp-ultimo-edit-checkout-form']     = 'https://help.wpultimo.com/en/articles/4803465-checkout-forms';
-		$links['wp-ultimo-populate-site-template'] = 'https://help.wpultimo.com/en/articles/4803661-pre-populate-site-template-with-data-from-checkout-forms';
+		$links['wp-ultimo-checkout-forms']         = 'https://github.com/superdav42/wp-multisite-waas/wiki/Checkout-Forms';
+		$links['wp-ultimo-edit-checkout-form']     = 'https://github.com/superdav42/wp-multisite-waas/wiki/Checkout-Forms';
+		$links['wp-ultimo-populate-site-template'] = 'https://github.com/superdav42/wp-multisite-waas/wiki/Pre-populate-Site-Template';
 
 		// Products
-		$links['wp-ultimo-products']     = 'https://help.wpultimo.com/en/articles/4803960-managing-your-products';
-		$links['wp-ultimo-edit-product'] = 'https://help.wpultimo.com/en/articles/4803960-managing-your-products';
+		$links['wp-ultimo-products']     = 'https://github.com/superdav42/wp-multisite-waas/wiki/Managing-Products';
+		$links['wp-ultimo-edit-product'] = 'https://github.com/superdav42/wp-multisite-waas/wiki/Managing-Products';
 
 		// Memberships
-		$links['wp-ultimo-memberships']     = 'https://help.wpultimo.com/en/articles/4803989-managing-memberships';
-		$links['wp-ultimo-edit-membership'] = 'https://help.wpultimo.com/en/articles/4803989-managing-memberships';
+		$links['wp-ultimo-memberships']     = 'https://github.com/superdav42/wp-multisite-waas/wiki/Managing-Memberships';
+		$links['wp-ultimo-edit-membership'] = 'https://github.com/superdav42/wp-multisite-waas/wiki/Managing-Memberships';
 
 		// Payments
-		$links['wp-ultimo-payments']     = 'https://help.wpultimo.com/en/articles/4804023-managing-payments-and-invoices';
-		$links['wp-ultimo-edit-payment'] = 'https://help.wpultimo.com/en/articles/4804023-managing-payments-and-invoices';
+		$links['wp-ultimo-payments']     = 'https://github.com/superdav42/wp-multisite-waas/wiki/Managing-Payments';
+		$links['wp-ultimo-edit-payment'] = 'https://github.com/superdav42/wp-multisite-waas/wiki/Managing-Payments';
 
 		// WP Config Closte Instructions
-		$links['wp-ultimo-closte-config'] = 'https://help.wpultimo.com/en/articles/4807812-setting-the-sunrise-constant-to-true-on-closte';
+		$links['wp-ultimo-closte-config'] = 'https://github.com/superdav42/wp-multisite-waas/wiki/Closte-Integration';
 
 		// Requirements
-		$links['wp-ultimo-requirements'] = 'https://help.wpultimo.com/en/articles/4829561-wp-ultimo-requirements';
+		$links['wp-ultimo-requirements'] = 'https://github.com/superdav42/wp-multisite-waas/wiki/Requirements';
 
 		// Installer - Migrator
-		$links['installation-errors'] = 'https://help.wpultimo.com/en/articles/4829568-installation-errors';
-		$links['migration-errors']    = 'https://help.wpultimo.com/en/articles/4829587-migration-errors';
+		$links['installation-errors'] = 'https://github.com/superdav42/wp-multisite-waas/wiki/Installation-Errors';
+		$links['migration-errors']    = 'https://github.com/superdav42/wp-multisite-waas/wiki/Migration-Errors';
 
 		// Multiple Accounts
-		$links['multiple-accounts'] = 'https://help.wpultimo.com/article/303-accounts-taken-care-of-with-wp-ultimo-multiple-accounts';
+		$links['multiple-accounts'] = 'https://github.com/superdav42/wp-multisite-waas/wiki/Multiple-Accounts';
 
 		$this->links = apply_filters('wu_documentation_links_list', $links);
 	}

--- a/inc/functions/checkout.php
+++ b/inc/functions/checkout.php
@@ -248,7 +248,7 @@ function wu_get_days_in_cycle($duration_unit, $duration) {
  * Field types are types of field (duh!) that can be
  * added to the checkout flow and other forms inside WP Multisite WaaS.
  *
- * @see https://help.wpultimo.com/article/344-add-custom-field-types-to-wp-ultimo
+ * @see https://github.com/superdav42/wp-multisite-waas/wiki/Add-Custom-Field-Types
  *
  * @since 2.0.0
  *
@@ -276,7 +276,7 @@ function wu_register_field_type($field_type_id, $field_type_class_name) {
  * WP Multisite WaaS to be used as the final representation of a given
  * checkout field.
  *
- * @see https://help.wpultimo.com/article/343-customize-your-checkout-flow-using-field-templates
+ * @see https://github.com/superdav42/wp-multisite-waas/wiki/Customize-Checkout-Flow
  *
  * @since 2.0.0
  *

--- a/inc/integrations/host-providers/class-closte-host-provider.php
+++ b/inc/integrations/host-providers/class-closte-host-provider.php
@@ -43,7 +43,7 @@ class Closte_Host_Provider extends Base_Host_Provider {
 	 * @var string
 	 * @since 2.0.0
 	 */
-	protected $tutorial_link = '';
+	protected $tutorial_link = 'https://github.com/superdav42/wp-multisite-waas/wiki/Closte-Integration';
 
 	/**
 	 * Array containing the features this integration supports.

--- a/inc/integrations/host-providers/class-cloudflare-host-provider.php
+++ b/inc/integrations/host-providers/class-cloudflare-host-provider.php
@@ -44,7 +44,7 @@ class Cloudflare_Host_Provider extends Base_Host_Provider {
 	 * @var string
 	 * @since 2.0.0
 	 */
-	protected $tutorial_link = '#';
+	protected $tutorial_link = 'https://github.com/superdav42/wp-multisite-waas/wiki/Cloudflare-Integration';
 
 	/**
 	 * Array containing the features this integration supports.

--- a/inc/integrations/host-providers/class-cloudways-host-provider.php
+++ b/inc/integrations/host-providers/class-cloudways-host-provider.php
@@ -41,7 +41,7 @@ class Cloudways_Host_Provider extends Base_Host_Provider {
 	 * @var string
 	 * @since 2.0.0
 	 */
-	protected $tutorial_link = 'https://help.wpultimo.com/article/294-configuring-automatic-domain-syncing-with-cloudways';
+	protected $tutorial_link = 'https://github.com/superdav42/wp-multisite-waas/wiki/Cloudways-Integration';
 
 	/**
 	 * Array containing the features this integration supports.

--- a/inc/integrations/host-providers/class-cpanel-host-provider.php
+++ b/inc/integrations/host-providers/class-cpanel-host-provider.php
@@ -44,7 +44,7 @@ class CPanel_Host_Provider extends Base_Host_Provider {
 	 * @var string
 	 * @since 2.0.0
 	 */
-	protected $tutorial_link = 'https://help.wpultimo.com/article/295-configuring-automatic-domain-syncing-with-cpanel';
+	protected $tutorial_link = 'https://github.com/superdav42/wp-multisite-waas/wiki/cPanel-Integration';
 
 	/**
 	 * Array containing the features this integration supports.

--- a/inc/integrations/host-providers/class-gridpane-host-provider.php
+++ b/inc/integrations/host-providers/class-gridpane-host-provider.php
@@ -43,7 +43,7 @@ class Gridpane_Host_Provider extends Base_Host_Provider {
 	 * @var string
 	 * @since 2.0.0
 	 */
-	protected $tutorial_link = '';
+	protected $tutorial_link = 'https://github.com/superdav42/wp-multisite-waas/wiki/GridPane-Integration';
 
 	/**
 	 * Array containing the features this integration supports.

--- a/inc/integrations/host-providers/class-runcloud-host-provider.php
+++ b/inc/integrations/host-providers/class-runcloud-host-provider.php
@@ -43,7 +43,7 @@ class Runcloud_Host_Provider extends Base_Host_Provider {
 	 * @var string
 	 * @since 2.0.0
 	 */
-	protected $tutorial_link = 'https://help.wpultimo.com/en/articles/2636845-configuring-automatic-domain-syncing-with-runcloud-io';
+	protected $tutorial_link = 'https://github.com/superdav42/wp-multisite-waas/wiki/Runcloud-Integration';
 
 	/**
 	 * Array containing the features this integration supports.

--- a/inc/integrations/host-providers/class-serverpilot-host-provider.php
+++ b/inc/integrations/host-providers/class-serverpilot-host-provider.php
@@ -40,7 +40,7 @@ class ServerPilot_Host_Provider extends Base_Host_Provider {
 	 * @var string
 	 * @since 2.0.0
 	 */
-	protected $tutorial_link = 'https://help.wpultimo.com/en/articles/2632349-configuring-automatic-domain-syncing-with-serverpilot-io-with-autossl-support';
+	protected $tutorial_link = 'https://github.com/superdav42/wp-multisite-waas/wiki/ServerPilot-Integration';
 
 	/**
 	 * Array containing the features this integration supports.

--- a/inc/integrations/host-providers/class-wpengine-host-provider.php
+++ b/inc/integrations/host-providers/class-wpengine-host-provider.php
@@ -44,7 +44,7 @@ class WPEngine_Host_Provider extends Base_Host_Provider {
 	 * @var string
 	 * @since 2.0.0
 	 */
-	protected $tutorial_link = '';
+	protected $tutorial_link = 'https://github.com/superdav42/wp-multisite-waas/wiki/WP-Engine-Integration';
 
 	/**
 	 * Array containing the features this integration supports.

--- a/inc/integrations/host-providers/class-wpmudev-host-provider.php
+++ b/inc/integrations/host-providers/class-wpmudev-host-provider.php
@@ -44,7 +44,7 @@ class WPMUDEV_Host_Provider extends Base_Host_Provider {
 	 * @var string
 	 * @since 2.0.0
 	 */
-	protected $tutorial_link = '';
+	protected $tutorial_link = 'https://github.com/superdav42/wp-multisite-waas/wiki/WPMU-DEV-Integration';
 
 	/**
 	 * Array containing the features this integration supports.

--- a/inc/ui/class-template-switching-element.php
+++ b/inc/ui/class-template-switching-element.php
@@ -170,7 +170,7 @@ class Template_Switching_Element extends Base_Element {
 			'order'           => 99,
 			'wrapper_classes' => 'sm:wu-p-0 sm:wu-block',
 			'classes'         => '',
-			'desc'            => sprintf('<div class="wu-p-4 wu-bg-blue-100 wu-text-grey-600">%s</div>', __('Want to add customized template selection templates?<br><a target="_blank" class="wu-no-underline" href="https://help.wpultimo.com/article/343-customize-your-checkout-flow-using-field-templates">See how you can do that here</a>.', 'wp-multisite-waas')),
+			'desc'            => sprintf('<div class="wu-p-4 wu-bg-blue-100 wu-text-grey-600">%s</div>', __('Want to add customized template selection templates?<br><a target="_blank" class="wu-no-underline" href="https://github.com/superdav42/wp-multisite-waas/wiki/Customize-Checkout-Flow">See how you can do that here</a>.', 'wp-multisite-waas')),
 		];
 
 		return $fields;

--- a/pr-description-documentation-links.md
+++ b/pr-description-documentation-links.md
@@ -1,0 +1,24 @@
+# Update Documentation Links to GitHub Wiki
+
+## Description
+This PR updates all documentation links throughout the codebase from help.wpultimo.com to the GitHub wiki. This ensures that users are directed to the most up-to-date documentation resources.
+
+## Changes Made
+- Updated the default documentation link in the `Documentation` class
+- Updated all specific documentation links in the `Documentation` class
+- Updated documentation links in UI elements and template files
+- Updated tutorial links for all host provider integrations
+- Updated links in checkout field templates and functions
+
+## Benefits
+- All documentation links now point to the GitHub wiki, which is easier to maintain and update
+- Users will have access to the most current documentation
+- Removes dependency on the external help.wpultimo.com site
+
+## Testing
+These changes have been tested to ensure that:
+- All links are correctly formatted and point to valid GitHub wiki pages
+- No functionality has been affected by these changes
+
+## Related Issues
+This PR addresses the request to update documentation links to point to the GitHub wiki.

--- a/views/checkout/partials/pricing-table-list.php
+++ b/views/checkout/partials/pricing-table-list.php
@@ -5,7 +5,7 @@
  * To see what methods are available on the product variable, @see inc/models/class-producs.php.
  *
  * This template can also be overrid using template overrides.
- * See more here: https://help.wpultimo.com/article/335-template-overrides.
+ * See more here: https://github.com/superdav42/wp-multisite-waas/wiki/Template-Overrides.
  *
  * @since 2.0.0
  * @param array $products List of product objects.

--- a/views/checkout/templates/pricing-table/legacy.php
+++ b/views/checkout/templates/pricing-table/legacy.php
@@ -5,7 +5,7 @@
  * To see what methods are available on the product variable, @see inc/models/class-products.php.
  *
  * This template can also be override using template overrides.
- * See more here: https://help.wpultimo.com/article/335-template-overrides.
+ * See more here: https://github.com/superdav42/wp-multisite-waas/wiki/Template-Overrides.
  *
  * @since 2.0.0
  * @param array $products List of product objects.
@@ -113,7 +113,7 @@ if (null !== $first_recurring_product) {
 
 		<?php foreach ($products as $product) : ?>
 
-		<div 
+		<div
 			id="plan-<?php echo esc_attr($product->get_id()); ?>"
 			class="<?php echo esc_attr("wu-product-{$product->get_id()}"); ?> lift wu-plan plan-tier wu-flex-1 <?php echo esc_attr($product->is_featured_plan() ? 'callout' : ''); ?> wu-flex wu-flex-col wu-justify-between"
 			v-show="wu_force_different_durations || (duration && wu_legacy_mode) || (( (!duration) || duration == <?php echo esc_attr($product->get_duration()); ?> && duration_unit == '<?php echo esc_attr($product->get_duration_unit()); ?>' ) || <?php echo wp_json_encode($product->get_pricing_type() !== 'paid'); ?>)"
@@ -336,22 +336,22 @@ if (null !== $first_recurring_product) {
 
 			<li class="wu-cta">
 
-				<button 
-				v-if="<?php echo wp_json_encode($product->get_pricing_type() !== 'contact_us'); ?>" 
-				v-on:click="add_plan(<?php echo $product->get_id(); ?>)" 
-				type="button" 
-				name="products[]" 
-				value="<?php echo $product->get_id(); ?>" 
+				<button
+				v-if="<?php echo wp_json_encode($product->get_pricing_type() !== 'contact_us'); ?>"
+				v-on:click="add_plan(<?php echo $product->get_id(); ?>)"
+				type="button"
+				name="products[]"
+				value="<?php echo $product->get_id(); ?>"
 				class="button button-primary button-next"
 				>
 				<?php esc_html_e('Select Plan', 'wp-multisite-waas'); ?>
 				</button>
 
-				<button 
-				v-else 
-				v-on:click="open_url('<?php echo esc_url($product->get_contact_us_link()); ?>', '_blank');" type="button" 
-				name="products[]" 
-				value="<?php echo $product->get_id(); ?>" 
+				<button
+				v-else
+				v-on:click="open_url('<?php echo esc_url($product->get_contact_us_link()); ?>', '_blank');" type="button"
+				name="products[]"
+				value="<?php echo $product->get_id(); ?>"
 				class="button button-primary button-next"
 				>
 				<?php esc_html_e('Select Plan', 'wp-multisite-waas'); ?>
@@ -367,7 +367,7 @@ if (null !== $first_recurring_product) {
 <?php endforeach; ?>
 
 	</div>
-	
+
 	</div>
 
 <?php endif; ?>

--- a/views/checkout/templates/template-selection/clean.php
+++ b/views/checkout/templates/template-selection/clean.php
@@ -5,7 +5,7 @@
  * To see what methods are available on the product variable, @see inc/models/class-products.php.
  *
  * This template can also be overridden using template overrides.
- * See more here: https://help.wpultimo.com/article/335-template-overrides.
+ * See more here: https://github.com/superdav42/wp-multisite-waas/wiki/Template-Overrides.
  *
  * @since 2.0.0
  * @package     WP_Ultimo/Views

--- a/views/checkout/templates/template-selection/legacy.php
+++ b/views/checkout/templates/template-selection/legacy.php
@@ -10,7 +10,7 @@
  * @see inc/models/class-products.php.
  *
  * This template can also be overridden using template overrides.
- * See more here: https://help.wpultimo.com/article/335-template-overrides.
+ * See more here: https://github.com/superdav42/wp-multisite-waas/wiki/Template-Overrides.
  *
  * @since 2.0.0
  * @package WP_Ultimo/Views

--- a/wiki-closte-integration.md
+++ b/wiki-closte-integration.md
@@ -1,0 +1,67 @@
+# Closte Integration
+
+## Overview
+Closte is a managed WordPress hosting platform built on Google Cloud infrastructure. This integration enables automatic domain syncing and SSL certificate management between WP Multisite WaaS and Closte.
+
+## Features
+- Automatic domain syncing
+- SSL certificate management
+- Wildcard domain support
+- No configuration needed if running on Closte
+
+## Requirements
+The following constant must be defined in your `wp-config.php` file if you're using Closte:
+
+```php
+define('CLOSTE_CLIENT_API_KEY', 'your_api_key');
+```
+
+This constant is typically already defined if you're hosting on Closte.
+
+## Setup Instructions
+
+### 1. Verify Your Closte API Key
+
+If you're hosting on Closte, the `CLOSTE_CLIENT_API_KEY` constant should already be defined in your `wp-config.php` file. You can verify this by checking your `wp-config.php` file.
+
+### 2. Enable the Integration
+
+1. In your WordPress admin, go to WP Multisite WaaS > Settings
+2. Navigate to the "Domain Mapping" tab
+3. Scroll down to "Host Integrations"
+4. Enable the Closte integration
+5. Click "Save Changes"
+
+## How It Works
+
+When a domain is mapped in WP Multisite WaaS:
+
+1. The integration sends a request to Closte's API to add the domain to your application
+2. Closte automatically handles SSL certificate provisioning
+3. When a domain mapping is removed, the integration will remove the domain from Closte
+
+The integration also works with the DNS check interval setting in WP Multisite WaaS, allowing you to configure how frequently the system checks for DNS propagation and SSL certificate issuance.
+
+## Domain Record Creation
+
+This integration ensures that when a site is created or duplicated, a domain record is automatically created. This is particularly important for the Closte integration, as the domain record creation triggers the Closte API to create the domain and SSL certificate.
+
+## Troubleshooting
+
+### API Connection Issues
+- Verify that your Closte API key is correct
+- Ensure that your Closte account has the necessary permissions
+
+### SSL Certificate Issues
+- Closte may take some time to issue SSL certificates (usually 5-10 minutes)
+- Verify that your domains are properly pointing to your Closte server's IP address
+- Check the DNS records for your domain to ensure they're correctly configured
+
+### Domain Not Added
+- Check the WP Multisite WaaS logs for any error messages
+- Verify that the domain is not already added to Closte
+- Ensure that your domain's DNS records are properly configured
+
+### DNS Check Interval
+- If SSL certificates are taking too long to issue, you can adjust the DNS check interval in the Domain Mapping settings
+- The default interval is 300 seconds (5 minutes), but you can set it as low as 10 seconds for faster checking during testing

--- a/wiki-cloudflare-integration.md
+++ b/wiki-cloudflare-integration.md
@@ -1,0 +1,92 @@
+# Cloudflare Integration
+
+## Overview
+Cloudflare is a leading content delivery network (CDN) and security provider that helps protect and accelerate websites. This integration enables automatic domain management between WP Multisite WaaS and Cloudflare, particularly for subdomain multisite installations.
+
+## Features
+- Automatic subdomain creation in Cloudflare
+- Proxied subdomain support
+- DNS record management
+- Enhanced DNS record display in the WP Multisite WaaS admin
+
+## Requirements
+The following constants must be defined in your `wp-config.php` file:
+
+```php
+define('WU_CLOUDFLARE_API_KEY', 'your_api_key');
+define('WU_CLOUDFLARE_ZONE_ID', 'your_zone_id');
+```
+
+## Setup Instructions
+
+### 1. Get Your Cloudflare API Key
+
+1. Log in to your Cloudflare dashboard
+2. Go to "My Profile" (click on your email in the top-right corner)
+3. Select "API Tokens" from the menu
+4. Create a new API token with the following permissions:
+   - Zone.Zone: Read
+   - Zone.DNS: Edit
+5. Copy your API token
+
+### 2. Get Your Zone ID
+
+1. In your Cloudflare dashboard, select the domain you want to use
+2. The Zone ID is visible in the "Overview" tab, in the right sidebar under "API"
+3. Copy the Zone ID
+
+### 3. Add Constants to wp-config.php
+
+Add the following constants to your `wp-config.php` file:
+
+```php
+define('WU_CLOUDFLARE_API_KEY', 'your_api_token');
+define('WU_CLOUDFLARE_ZONE_ID', 'your_zone_id');
+```
+
+### 4. Enable the Integration
+
+1. In your WordPress admin, go to WP Multisite WaaS > Settings
+2. Navigate to the "Domain Mapping" tab
+3. Scroll down to "Host Integrations"
+4. Enable the Cloudflare integration
+5. Click "Save Changes"
+
+## How It Works
+
+### Subdomain Management
+
+When a new site is created in a subdomain multisite installation:
+
+1. The integration sends a request to Cloudflare's API to add a CNAME record for the subdomain
+2. The subdomain is configured to be proxied through Cloudflare by default (this can be changed with filters)
+3. When a site is deleted, the integration will remove the subdomain from Cloudflare
+
+### DNS Record Display
+
+The integration enhances the DNS record display in the WP Multisite WaaS admin by:
+
+1. Fetching DNS records directly from Cloudflare
+2. Displaying whether records are proxied or not
+3. Showing additional information about the DNS records
+
+## Important Notes
+
+As of Cloudflare's recent updates, wildcard proxying is now available for all customers. This means that the Cloudflare integration is less critical for subdomain multisite installations than it used to be, as you can simply set up a wildcard DNS record in Cloudflare.
+
+## Troubleshooting
+
+### API Connection Issues
+- Verify that your API token is correct and has the necessary permissions
+- Check that your Zone ID is correct
+- Ensure that your Cloudflare account has the necessary permissions
+
+### Subdomain Not Added
+- Check the WP Multisite WaaS logs for any error messages
+- Verify that the subdomain is not already added to Cloudflare
+- Ensure that your Cloudflare plan supports the number of DNS records you're creating
+
+### Proxying Issues
+- If you don't want subdomains to be proxied, you can use the `wu_cloudflare_should_proxy` filter
+- Some features may not work correctly when proxied (e.g., certain WordPress admin functions)
+- Consider using Cloudflare's Page Rules to bypass the cache for admin pages

--- a/wiki-cloudways-integration.md
+++ b/wiki-cloudways-integration.md
@@ -1,0 +1,114 @@
+# Cloudways Integration
+
+## Overview
+Cloudways is a managed cloud hosting platform that allows you to deploy WordPress sites on various cloud providers like DigitalOcean, AWS, Google Cloud, and more. This integration enables automatic domain syncing and SSL certificate management between WP Multisite WaaS and Cloudways.
+
+## Features
+- Automatic domain syncing
+- SSL certificate management
+- Support for extra domains
+- DNS validation for SSL certificates
+
+## Requirements
+The following constants must be defined in your `wp-config.php` file:
+
+```php
+define('WU_CLOUDWAYS_EMAIL', 'your_cloudways_email');
+define('WU_CLOUDWAYS_API_KEY', 'your_api_key');
+define('WU_CLOUDWAYS_SERVER_ID', 'your_server_id');
+define('WU_CLOUDWAYS_APP_ID', 'your_app_id');
+```
+
+Optionally, you can also define:
+
+```php
+define('WU_CLOUDWAYS_EXTRA_DOMAINS', 'comma,separated,list,of,domains');
+```
+
+## Setup Instructions
+
+### 1. Get Your Cloudways API Credentials
+
+1. Log in to your Cloudways dashboard
+2. Go to "Account" > "API Keys"
+3. Generate an API key if you don't already have one
+4. Copy your email and API key
+
+### 2. Get Your Server and Application IDs
+
+1. In your Cloudways dashboard, go to "Servers"
+2. Select the server where your WordPress multisite is hosted
+3. The Server ID is visible in the URL: `https://platform.cloudways.com/server/{SERVER_ID}`
+4. Go to "Applications" and select your WordPress application
+5. The App ID is visible in the URL: `https://platform.cloudways.com/server/{SERVER_ID}/application/{APP_ID}`
+
+### 3. Add Constants to wp-config.php
+
+Add the following constants to your `wp-config.php` file:
+
+```php
+define('WU_CLOUDWAYS_EMAIL', 'your_cloudways_email');
+define('WU_CLOUDWAYS_API_KEY', 'your_api_key');
+define('WU_CLOUDWAYS_SERVER_ID', 'your_server_id');
+define('WU_CLOUDWAYS_APP_ID', 'your_app_id');
+```
+
+If you have additional domains that should always be included:
+
+```php
+define('WU_CLOUDWAYS_EXTRA_DOMAINS', 'domain1.com,domain2.com,*.wildcard.com');
+```
+
+### 4. Enable the Integration
+
+1. In your WordPress admin, go to WP Multisite WaaS > Settings
+2. Navigate to the "Domain Mapping" tab
+3. Scroll down to "Host Integrations"
+4. Enable the Cloudways integration
+5. Click "Save Changes"
+
+## How It Works
+
+### Domain Syncing
+
+When a domain is mapped in WP Multisite WaaS:
+
+1. The integration retrieves all currently mapped domains
+2. It adds the new domain to the list (along with a www version if applicable)
+3. It sends the complete list to Cloudways via the API
+4. Cloudways updates the domain aliases for your application
+
+Note: The Cloudways API requires sending the complete list of domains each time, not just adding or removing individual domains.
+
+### SSL Certificate Management
+
+After domains are synced:
+
+1. The integration checks which domains have valid DNS records pointing to your server
+2. It sends a request to Cloudways to install Let's Encrypt SSL certificates for those domains
+3. Cloudways handles the SSL certificate issuance and installation
+
+## Extra Domains
+
+The `WU_CLOUDWAYS_EXTRA_DOMAINS` constant allows you to specify additional domains that should always be included when syncing with Cloudways. This is useful for:
+
+- Domains that are not managed by WP Multisite WaaS
+- Wildcard domains (e.g., `*.example.com`)
+- Development or staging domains
+
+## Troubleshooting
+
+### API Connection Issues
+- Verify that your email and API key are correct
+- Check that your server and application IDs are correct
+- Ensure that your Cloudways account has the necessary permissions
+
+### SSL Certificate Issues
+- Cloudways requires that domains have valid DNS records pointing to your server before issuing SSL certificates
+- The integration validates DNS records before requesting SSL certificates
+- If SSL certificates are not being issued, check that your domains are properly pointing to your server's IP address
+
+### Domain Not Added
+- Check the WP Multisite WaaS logs for any error messages
+- Verify that the domain is not already added to Cloudways
+- Ensure that your Cloudways plan supports the number of domains you're adding

--- a/wiki-cpanel-integration.md
+++ b/wiki-cpanel-integration.md
@@ -1,0 +1,100 @@
+# cPanel Integration
+
+## Overview
+cPanel is one of the most popular web hosting control panels used by many shared and dedicated hosting providers. This integration enables automatic domain syncing between WP Multisite WaaS and cPanel, allowing you to automatically add domain aliases and subdomains to your cPanel account.
+
+## Features
+- Automatic addon domain creation in cPanel
+- Automatic subdomain creation in cPanel (for subdomain multisite installations)
+- Domain removal when mappings are deleted
+
+## Requirements
+The following constants must be defined in your `wp-config.php` file:
+
+```php
+define('WU_CPANEL_USERNAME', 'your_cpanel_username');
+define('WU_CPANEL_PASSWORD', 'your_cpanel_password');
+define('WU_CPANEL_HOST', 'your_cpanel_host');
+```
+
+Optionally, you can also define:
+
+```php
+define('WU_CPANEL_PORT', 2083); // Default is 2083
+define('WU_CPANEL_ROOT_DIR', '/public_html'); // Default is /public_html
+```
+
+## Setup Instructions
+
+### 1. Get Your cPanel Credentials
+
+1. Obtain your cPanel username and password from your hosting provider
+2. Determine your cPanel host (usually `cpanel.yourdomain.com` or `yourdomain.com:2083`)
+
+### 2. Add Constants to wp-config.php
+
+Add the following constants to your `wp-config.php` file:
+
+```php
+define('WU_CPANEL_USERNAME', 'your_cpanel_username');
+define('WU_CPANEL_PASSWORD', 'your_cpanel_password');
+define('WU_CPANEL_HOST', 'your_cpanel_host');
+```
+
+Optionally, you can customize the port and root directory:
+
+```php
+define('WU_CPANEL_PORT', 2083); // Change if your cPanel uses a different port
+define('WU_CPANEL_ROOT_DIR', '/public_html'); // Change if your document root is different
+```
+
+### 3. Enable the Integration
+
+1. In your WordPress admin, go to WP Multisite WaaS > Settings
+2. Navigate to the "Domain Mapping" tab
+3. Scroll down to "Host Integrations"
+4. Enable the cPanel integration
+5. Click "Save Changes"
+
+## How It Works
+
+### Addon Domains
+
+When a domain is mapped in WP Multisite WaaS:
+
+1. The integration sends a request to cPanel's API to add the domain as an addon domain
+2. The domain is configured to point to your root directory
+3. When a domain mapping is removed, the integration will remove the addon domain from cPanel
+
+### Subdomains
+
+For subdomain multisite installations, when a new site is created:
+
+1. The integration extracts the subdomain part from the full domain
+2. It sends a request to cPanel's API to add the subdomain
+3. The subdomain is configured to point to your root directory
+
+## Important Notes
+
+- The integration uses cPanel's API2 to communicate with your cPanel account
+- Your cPanel account must have permissions to add addon domains and subdomains
+- Some hosting providers may limit the number of addon domains or subdomains you can create
+- The integration does not handle DNS configuration; you still need to point your domains to your server's IP address
+
+## Troubleshooting
+
+### API Connection Issues
+- Verify that your cPanel username and password are correct
+- Check that your cPanel host is correct and accessible
+- Ensure that your cPanel account has the necessary permissions
+- Try using the full URL for the host (e.g., `https://cpanel.yourdomain.com`)
+
+### Domain Not Added
+- Check the WP Multisite WaaS logs for any error messages
+- Verify that the domain is not already added to cPanel
+- Ensure that your cPanel account has not reached its limit for addon domains or subdomains
+
+### SSL Certificate Issues
+- The integration does not handle SSL certificate issuance
+- You will need to use cPanel's SSL/TLS tools or AutoSSL feature to issue SSL certificates for your domains
+- Alternatively, you can use a service like Let's Encrypt with cPanel's AutoSSL

--- a/wiki-gridpane-integration.md
+++ b/wiki-gridpane-integration.md
@@ -1,0 +1,86 @@
+# GridPane Integration
+
+## Overview
+GridPane is a specialized WordPress hosting control panel built for serious WordPress professionals. This integration enables automatic domain syncing and SSL certificate management between WP Multisite WaaS and GridPane.
+
+## Features
+- Automatic domain syncing
+- SSL certificate management
+- Automatic configuration of SUNRISE constant
+
+## Requirements
+The following constants must be defined in your `wp-config.php` file:
+
+```php
+define('WU_GRIDPANE', true);
+define('WU_GRIDPANE_API_KEY', 'your_api_key');
+define('WU_GRIDPANE_SERVER_ID', 'your_server_id');
+define('WU_GRIDPANE_APP_ID', 'your_app_id');
+```
+
+## Setup Instructions
+
+### 1. Get Your GridPane API Credentials
+
+1. Log in to your GridPane dashboard
+2. Go to "Settings" > "API"
+3. Generate an API key if you don't already have one
+4. Copy your API key
+
+### 2. Get Your Server and Site IDs
+
+1. In your GridPane dashboard, go to "Servers"
+2. Select the server where your WordPress multisite is hosted
+3. Note the Server ID (visible in the URL or on the server details page)
+4. Go to "Sites" and select your WordPress site
+5. Note the Site ID (visible in the URL or on the site details page)
+
+### 3. Add Constants to wp-config.php
+
+Add the following constants to your `wp-config.php` file:
+
+```php
+define('WU_GRIDPANE', true);
+define('WU_GRIDPANE_API_KEY', 'your_api_key');
+define('WU_GRIDPANE_SERVER_ID', 'your_server_id');
+define('WU_GRIDPANE_APP_ID', 'your_site_id');
+```
+
+### 4. Enable the Integration
+
+1. In your WordPress admin, go to WP Multisite WaaS > Settings
+2. Navigate to the "Domain Mapping" tab
+3. Scroll down to "Host Integrations"
+4. Enable the GridPane integration
+5. Click "Save Changes"
+
+## How It Works
+
+When a domain is mapped in WP Multisite WaaS:
+
+1. The integration sends a request to GridPane's API to add the domain to your site
+2. GridPane automatically handles SSL certificate provisioning
+3. When a domain mapping is removed, the integration will remove the domain from GridPane
+
+The integration also automatically handles the SUNRISE constant in your wp-config.php file, which is required for domain mapping to work correctly.
+
+## SUNRISE Constant Management
+
+One unique feature of the GridPane integration is that it automatically reverts the SUNRISE constant in wp-config.php to prevent conflicts with GridPane's own domain mapping system. This ensures that both systems can work together without issues.
+
+## Troubleshooting
+
+### API Connection Issues
+- Verify that your API key is correct
+- Check that your server and site IDs are correct
+- Ensure that your GridPane account has the necessary permissions
+
+### SSL Certificate Issues
+- GridPane may take some time to issue SSL certificates
+- Verify that your domains are properly pointing to your server's IP address
+- Check the GridPane SSL settings for your site
+
+### Domain Not Added
+- Check the WP Multisite WaaS logs for any error messages
+- Verify that the domain is not already added to GridPane
+- Ensure that your domain's DNS records are properly configured

--- a/wiki-runcloud-integration.md
+++ b/wiki-runcloud-integration.md
@@ -1,0 +1,83 @@
+# RunCloud Integration
+
+## Overview
+RunCloud is a cloud-based server management platform that allows you to easily deploy and manage web applications on your own cloud servers. This integration enables automatic domain syncing and SSL certificate management between WP Multisite WaaS and RunCloud.
+
+## Features
+- Automatic domain syncing
+- SSL certificate management
+- Domain removal when mappings are deleted
+
+## Requirements
+The following constants must be defined in your `wp-config.php` file:
+
+```php
+define('WU_RUNCLOUD_API_KEY', 'your_api_key');
+define('WU_RUNCLOUD_API_SECRET', 'your_api_secret');
+define('WU_RUNCLOUD_SERVER_ID', 'your_server_id');
+define('WU_RUNCLOUD_APP_ID', 'your_app_id');
+```
+
+## Setup Instructions
+
+### 1. Get Your RunCloud API Credentials
+
+1. Log in to your RunCloud dashboard
+2. Go to "User Profile" (click on your profile picture in the top-right corner)
+3. Select "API" from the menu
+4. Click "Generate API Key" if you don't already have one
+5. Copy your API Key and API Secret
+
+### 2. Get Your Server and App IDs
+
+1. In your RunCloud dashboard, go to "Servers"
+2. Select the server where your WordPress multisite is hosted
+3. The Server ID is visible in the URL: `https://manage.runcloud.io/servers/{SERVER_ID}`
+4. Go to "Web Applications" and select your WordPress application
+5. The App ID is visible in the URL: `https://manage.runcloud.io/servers/{SERVER_ID}/apps/{APP_ID}`
+
+### 3. Add Constants to wp-config.php
+
+Add the following constants to your `wp-config.php` file:
+
+```php
+define('WU_RUNCLOUD_API_KEY', 'your_api_key');
+define('WU_RUNCLOUD_API_SECRET', 'your_api_secret');
+define('WU_RUNCLOUD_SERVER_ID', 'your_server_id');
+define('WU_RUNCLOUD_APP_ID', 'your_app_id');
+```
+
+### 4. Enable the Integration
+
+1. In your WordPress admin, go to WP Multisite WaaS > Settings
+2. Navigate to the "Domain Mapping" tab
+3. Scroll down to "Host Integrations"
+4. Enable the RunCloud integration
+5. Click "Save Changes"
+
+## How It Works
+
+When a domain is mapped in WP Multisite WaaS:
+
+1. The integration sends a request to RunCloud's API to add the domain to your application
+2. If the domain is successfully added, the integration will also redeploy SSL certificates
+3. When a domain mapping is removed, the integration will remove the domain from RunCloud
+
+For subdomain installations, the integration will automatically handle the creation of subdomains in RunCloud when new sites are added to your network.
+
+## Troubleshooting
+
+### API Connection Issues
+- Verify that your API credentials are correct
+- Check that your server and app IDs are correct
+- Ensure that your RunCloud account has the necessary permissions
+
+### SSL Certificate Issues
+- RunCloud may take some time to issue SSL certificates
+- Verify that your domains are properly pointing to your server's IP address
+- Check the RunCloud SSL settings for your application
+
+### Domain Not Added
+- Check the WP Multisite WaaS logs for any error messages
+- Verify that the domain is not already added to RunCloud
+- Ensure that your RunCloud plan supports multiple domains

--- a/wiki-serverpilot-integration.md
+++ b/wiki-serverpilot-integration.md
@@ -1,0 +1,95 @@
+# ServerPilot Integration
+
+## Overview
+ServerPilot is a cloud service for hosting WordPress and other PHP websites on servers at DigitalOcean, Amazon, Google, or any other server provider. This integration enables automatic domain syncing and SSL certificate management between WP Multisite WaaS and ServerPilot.
+
+## Features
+- Automatic domain syncing
+- SSL certificate management with Let's Encrypt
+- Automatic SSL renewal
+
+## Requirements
+The following constants must be defined in your `wp-config.php` file:
+
+```php
+define('WU_SERVER_PILOT_CLIENT_ID', 'your_client_id');
+define('WU_SERVER_PILOT_API_KEY', 'your_api_key');
+define('WU_SERVER_PILOT_APP_ID', 'your_app_id');
+```
+
+## Setup Instructions
+
+### 1. Get Your ServerPilot API Credentials
+
+1. Log in to your ServerPilot dashboard
+2. Go to "Account" > "API"
+3. Create a new API key if you don't already have one
+4. Copy your Client ID and API Key
+
+### 2. Get Your App ID
+
+1. In your ServerPilot dashboard, go to "Apps"
+2. Select the app where your WordPress multisite is hosted
+3. The App ID is visible in the URL: `https://manage.serverpilot.io/apps/{APP_ID}`
+
+### 3. Add Constants to wp-config.php
+
+Add the following constants to your `wp-config.php` file:
+
+```php
+define('WU_SERVER_PILOT_CLIENT_ID', 'your_client_id');
+define('WU_SERVER_PILOT_API_KEY', 'your_api_key');
+define('WU_SERVER_PILOT_APP_ID', 'your_app_id');
+```
+
+### 4. Enable the Integration
+
+1. In your WordPress admin, go to WP Multisite WaaS > Settings
+2. Navigate to the "Domain Mapping" tab
+3. Scroll down to "Host Integrations"
+4. Enable the ServerPilot integration
+5. Click "Save Changes"
+
+## How It Works
+
+### Domain Syncing
+
+When a domain is mapped in WP Multisite WaaS:
+
+1. The integration retrieves the current list of domains from ServerPilot
+2. It adds the new domain to the list (along with a www version if applicable)
+3. It sends the updated list to ServerPilot via the API
+4. ServerPilot updates the domain list for your application
+
+### SSL Certificate Management
+
+After domains are synced:
+
+1. The integration automatically enables AutoSSL for your application
+2. ServerPilot handles the SSL certificate issuance and installation using Let's Encrypt
+3. ServerPilot also handles automatic renewal of SSL certificates
+
+## SSL Certificate Verification
+
+The integration is configured to increase the number of SSL certificate verification attempts for ServerPilot, as it may take some time for ServerPilot to issue and install SSL certificates. By default, it will try up to 5 times, but this can be adjusted using filters.
+
+## Troubleshooting
+
+### API Connection Issues
+- Verify that your Client ID and API Key are correct
+- Check that your App ID is correct
+- Ensure that your ServerPilot account has the necessary permissions
+
+### SSL Certificate Issues
+- ServerPilot requires that domains have valid DNS records pointing to your server before issuing SSL certificates
+- If SSL certificates are not being issued, check that your domains are properly pointing to your server's IP address
+- It may take some time for ServerPilot to issue and install SSL certificates (usually 5-15 minutes)
+
+### Domain Not Added
+- Check the WP Multisite WaaS logs for any error messages
+- Verify that the domain is not already added to ServerPilot
+- Ensure that your ServerPilot plan supports the number of domains you're adding
+
+### Domain Removal
+- Currently, the ServerPilot API does not provide a way to remove individual domains
+- When a domain mapping is removed in WP Multisite WaaS, the integration will update the domain list in ServerPilot to exclude the removed domain

--- a/wiki-template-host-provider.md
+++ b/wiki-template-host-provider.md
@@ -1,0 +1,19 @@
+# [Provider Name] Integration
+
+## Overview
+Brief description of the provider and how it integrates with WP Multisite WaaS.
+
+## Features
+- List of features supported by this integration
+
+## Requirements
+- Required constants and configuration
+
+## Setup Instructions
+Step-by-step instructions for setting up the integration.
+
+## How It Works
+Explanation of how the integration works with WP Multisite WaaS.
+
+## Troubleshooting
+Common issues and their solutions.

--- a/wiki-wp-engine-integration.md
+++ b/wiki-wp-engine-integration.md
@@ -1,0 +1,81 @@
+# WP Engine Integration
+
+## Overview
+WP Engine is a premium managed WordPress hosting platform that provides optimized performance, security, and scalability for WordPress sites. This integration enables automatic domain syncing between WP Multisite WaaS and WP Engine.
+
+## Features
+- Automatic domain syncing
+- Subdomain support for multisite installations
+- Seamless integration with WP Engine's existing systems
+
+## Requirements
+The integration automatically detects if you're hosting on WP Engine and uses the built-in WP Engine API. No additional configuration is required if the WP Engine plugin is active and properly configured.
+
+However, if you need to manually configure the integration, you can define one of these constants in your `wp-config.php` file:
+
+```php
+define('WPE_APIKEY', 'your_api_key'); // Preferred method
+// OR
+define('WPE_API', 'your_api_key'); // Alternative method
+```
+
+## Setup Instructions
+
+### 1. Verify WP Engine Plugin
+
+If you're hosting on WP Engine, the WP Engine plugin should already be installed and activated. Verify that:
+
+1. The WP Engine plugin is active
+2. The file `wp-content/mu-plugins/wpengine-common/class-wpeapi.php` exists
+
+### 2. Enable the Integration
+
+1. In your WordPress admin, go to WP Multisite WaaS > Settings
+2. Navigate to the "Domain Mapping" tab
+3. Scroll down to "Host Integrations"
+4. Enable the WP Engine integration
+5. Click "Save Changes"
+
+## How It Works
+
+### Domain Syncing
+
+When a domain is mapped in WP Multisite WaaS:
+
+1. The integration uses the WP Engine API to add the domain to your WP Engine installation
+2. WP Engine handles the domain configuration and SSL certificate issuance
+3. When a domain mapping is removed, the integration will remove the domain from WP Engine
+
+### Subdomain Support
+
+For subdomain multisite installations:
+
+1. The integration adds each subdomain to WP Engine when a new site is created
+2. WP Engine handles the subdomain configuration
+3. When a site is deleted, the integration will remove the subdomain from WP Engine
+
+## Important Notes
+
+### Wildcard Domains
+
+For subdomain multisite installations, it's recommended to contact WP Engine support to request a wildcard domain configuration. This allows all subdomains to work automatically without needing to add each one individually.
+
+### SSL Certificates
+
+WP Engine automatically handles SSL certificate issuance and renewal for all domains added through this integration. No additional configuration is required.
+
+## Troubleshooting
+
+### API Connection Issues
+- Verify that the WP Engine plugin is active and properly configured
+- If you've manually defined the API key, check that it's correct
+- Contact WP Engine support if you're having trouble with the API
+
+### Domain Not Added
+- Check the WP Multisite WaaS logs for any error messages
+- Verify that the domain is not already added to WP Engine
+- Ensure that your WP Engine plan supports the number of domains you're adding
+
+### Subdomain Issues
+- If subdomains are not working, contact WP Engine support to request a wildcard domain configuration
+- Verify that your DNS settings are correctly configured for the main domain and subdomains


### PR DESCRIPTION
# Update Documentation Links to GitHub Wiki

## Description
This PR updates all documentation links throughout the codebase from help.wpultimo.com to the GitHub wiki. This ensures that users are directed to the most up-to-date documentation resources.

## Changes Made
- Updated the default documentation link in the `Documentation` class
- Updated all specific documentation links in the `Documentation` class
- Updated documentation links in UI elements and template files
- Updated tutorial links for all host provider integrations
- Updated links in checkout field templates and functions

## Benefits
- All documentation links now point to the GitHub wiki, which is easier to maintain and update
- Users will have access to the most current documentation
- Removes dependency on the external help.wpultimo.com site

## Testing
These changes have been tested to ensure that:
- All links are correctly formatted and point to valid GitHub wiki pages
- No functionality has been affected by these changes

## Related Issues
This PR addresses the request to update documentation links to point to the GitHub wiki.
