### PR TITLE
Fix gateway_customer_id type from integer to string in membership-update schema

### DIFF
--- a/inc/api/schemas/membership-update.php
+++ b/inc/api/schemas/membership-update.php
@@ -130,7 +130,7 @@ return [
 	],
 	'gateway_customer_id'         => [
 		'description' => __('The ID of the customer on the payment gateway database.', 'multisite-ultimate'),
-		'type'        => 'integer',
+		'type'        => 'string',
 		'required'    => false,
 	],
 	'gateway_subscription_id'     => [


### PR DESCRIPTION
## Summary
- Fix gateway_customer_id type from integer to string in membership-update schema
- Resolves API validation errors when passing gateway customer IDs

## Problem
The API returns "Bad request - Invalid parameter(s): gateway_customer_id" because the schema defines `gateway_customer_id` as `integer` type instead of `string`.

## Solution
Changed the type of `gateway_customer_id` from `'integer'` to `'string'` in `/inc/api/schemas/membership-update.php`.

## Changes
- Line 133: Changed `'type' => 'integer'` to `'type' => 'string'` for `gateway_customer_id` field

## Justification
Gateway customer IDs are typically strings rather than integers in most payment gateways (Stripe, PayPal, etc.), so this change aligns the schema with common API practices and fixes validation errors.

🤖 Generated with [Claude Code](https://claude.ai/code)