### PR TITLE
API: Fix gateway_customer_id type from integer to string

### DIFF
--- a/inc/api/schemas/membership-update.php
+++ b/inc/api/schemas/membership-update.php
@@ -130,7 +130,7 @@ return [
 	],
 	'gateway_customer_id'         => [
 		'description' => __('The ID of the customer on the payment gateway database.', 'multisite-ultimate'),
-		'type'        => 'integer',
+		'type'        => 'string',
 		'required'    => false,
 	],
 	'gateway_subscription_id'     => [


### PR DESCRIPTION
## Summary
Fix API schema validation error for gateway_customer_id field in membership update endpoint.

## Issue
The membership-update API schema defined gateway_customer_id as integer, but payment gateways like Stripe return string values (e.g., "cus_xxxxx").

## Changes
- Updated membership-update schema to accept gateway_customer_id as string type
- Maintains backward compatibility
- Fixes API validation errors during membership updates

## Test plan
- [x] Test membership update with Stripe customer ID
- [x] Verify API validation passes
- [x] Check backward compatibility

Resolves gateway customer ID type mismatch in API.