### PR TITLE
Fix Line Items deserialization in admin interface

### DIFF
--- a/inc/models/class-payment.php
+++ b/inc/models/class-payment.php
@@ -600,6 +600,14 @@ class Payment extends Base_Model {
 		if (null === $this->line_items) {
 			$line_items = (array) $this->get_meta('wu_line_items');
 
+			// Convert arrays back to Line_Item objects
+			$line_items = array_map(function($item) {
+				if (is_array($item)) {
+					return new \WP_Ultimo\Checkout\Line_Item($item);
+				}
+				return $item;
+			}, $line_items);
+	
 			$this->line_items = array_filter($line_items);
 		}
 


### PR DESCRIPTION
## Summary
• Fix Line Items deserialization issues in payment admin interface
• Convert array data back to Line_Item objects when loading from database
• Prevents errors when viewing payments with line items in admin

## Test plan
- [x] Verify line items display correctly in admin
- [x] Test payment creation and editing with line items
- [x] Confirm no serialization errors in logs