### PR TITLE
Fix API validation: Change gateway_customer_id type to string in membership-create schema

### DIFF
--- a/inc/api/schemas/membership-create.php
+++ b/inc/api/schemas/membership-create.php
@@ -130,7 +130,7 @@ return [
 	],
 	'gateway_customer_id'         => [
 		'description' => __('The ID of the customer on the payment gateway database.', 'multisite-ultimate'),
-		'type'        => 'integer',
+		'type'        => 'string',
 		'required'    => false,
 	],
 	'gateway_subscription_id'     => [


### PR DESCRIPTION
###   **Fixes "Bad request - Invalid parameter(s): gateway_customer_id" error when creating memberships via POST API.**

Gateway customer IDs are typically strings rather than integers in most payment gateways (Stripe, PayPal, etc.). This change aligns the membership-create schema with the membership-update schema which was already corrected.

###   Changes:
  - inc/api/schemas/membership-create.php: Change gateway_customer_id type from 'integer' to 'string'

  This resolves API validation errors when integrating with external tools like N8N for membership creation workflows.