### PR TITLE
Fix: Add defensive checks for Slim SEO plugin compatibility

### DIFF
--- a/inc/ui/class-account-summary-element.php
+++ b/inc/ui/class-account-summary-element.php
@@ -294,6 +294,11 @@ class Account_Summary_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
+		// Defensive check - setup() may have been called but site can still be null
+		if ( ! $this->site) {
+			return '';
+		}
+
 		$atts = array_merge($atts, $this->atts);
 
 		$atts['site'] = $this->site;

--- a/inc/ui/class-account-summary-element.php
+++ b/inc/ui/class-account-summary-element.php
@@ -296,6 +296,7 @@ class Account_Summary_Element extends Base_Element {
 
 		// Defensive check - setup() may have been called but site can still be null
 		if ( ! $this->site) {
+			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'));
 			return '';
 		}
 

--- a/inc/ui/class-billing-info-element.php
+++ b/inc/ui/class-billing-info-element.php
@@ -272,6 +272,11 @@ class Billing_Info_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
+		// Defensive check - setup() may have been called but membership can still be null
+		if ( ! $this->membership) {
+			return '';
+		}
+
 		$atts['membership'] = $this->membership;
 
 		$atts['billing_address'] = $this->membership->get_billing_address();

--- a/inc/ui/class-billing-info-element.php
+++ b/inc/ui/class-billing-info-element.php
@@ -274,6 +274,7 @@ class Billing_Info_Element extends Base_Element {
 
 		// Defensive check - setup() may have been called but membership can still be null
 		if ( ! $this->membership) {
+			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'));
 			return '';
 		}
 

--- a/inc/ui/class-current-site-element.php
+++ b/inc/ui/class-current-site-element.php
@@ -352,6 +352,11 @@ class Current_Site_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
+		// Defensive check - setup() may have been called but site can still be null
+		if ( ! $this->site) {
+			return '';
+		}
+
 		$actions = [
 			'visit_site' => [
 				'label'        => __('Visit Site', 'multisite-ultimate'),

--- a/inc/ui/class-current-site-element.php
+++ b/inc/ui/class-current-site-element.php
@@ -354,6 +354,7 @@ class Current_Site_Element extends Base_Element {
 
 		// Defensive check - setup() may have been called but site can still be null
 		if ( ! $this->site) {
+			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'));
 			return '';
 		}
 

--- a/inc/ui/class-invoices-element.php
+++ b/inc/ui/class-invoices-element.php
@@ -274,6 +274,11 @@ class Invoices_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
+		// Defensive check - setup() may have been called but membership can still be null
+		if ( ! $this->membership) {
+			return '';
+		}
+
 		$atts['membership'] = $this->membership;
 
 		return wu_get_template_contents('dashboard-widgets/invoices', $atts);

--- a/inc/ui/class-invoices-element.php
+++ b/inc/ui/class-invoices-element.php
@@ -276,6 +276,7 @@ class Invoices_Element extends Base_Element {
 
 		// Defensive check - setup() may have been called but membership can still be null
 		if ( ! $this->membership) {
+			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'));
 			return '';
 		}
 

--- a/inc/ui/class-limits-element.php
+++ b/inc/ui/class-limits-element.php
@@ -240,6 +240,11 @@ class Limits_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
+		// Defensive check - setup() may have been called but site can still be null
+		if ( ! $this->site) {
+			return '';
+		}
+
 		$post_types = get_post_types(
 			[
 				'public' => true,

--- a/inc/ui/class-limits-element.php
+++ b/inc/ui/class-limits-element.php
@@ -242,6 +242,7 @@ class Limits_Element extends Base_Element {
 
 		// Defensive check - setup() may have been called but site can still be null
 		if ( ! $this->site) {
+			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'));
 			return '';
 		}
 


### PR DESCRIPTION
- Add null checks in UI element output methods
- Prevent errors when site/membership objects are null
- Ensures compatibility with Slim SEO plugin that calls output() directly
- Defensive programming approach for robustness