### PR TITLE
Revert "Fix: Add defensive checks for Slim SEO plugin compatibility"

### DIFF
--- a/inc/ui/class-account-summary-element.php
+++ b/inc/ui/class-account-summary-element.php
@@ -294,12 +294,6 @@ class Account_Summary_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
-		// Defensive check - setup() may have been called but site can still be null
-		if ( ! $this->site) {
-			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'));
-			return '';
-		}
-
 		$atts = array_merge($atts, $this->atts);
 
 		$atts['site'] = $this->site;

--- a/inc/ui/class-billing-info-element.php
+++ b/inc/ui/class-billing-info-element.php
@@ -272,12 +272,6 @@ class Billing_Info_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
-		// Defensive check - setup() may have been called but membership can still be null
-		if ( ! $this->membership) {
-			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'));
-			return '';
-		}
-
 		$atts['membership'] = $this->membership;
 
 		$atts['billing_address'] = $this->membership->get_billing_address();

--- a/inc/ui/class-current-site-element.php
+++ b/inc/ui/class-current-site-element.php
@@ -352,12 +352,6 @@ class Current_Site_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
-		// Defensive check - setup() may have been called but site can still be null
-		if ( ! $this->site) {
-			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'));
-			return '';
-		}
-
 		$actions = [
 			'visit_site' => [
 				'label'        => __('Visit Site', 'multisite-ultimate'),

--- a/inc/ui/class-invoices-element.php
+++ b/inc/ui/class-invoices-element.php
@@ -274,12 +274,6 @@ class Invoices_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
-		// Defensive check - setup() may have been called but membership can still be null
-		if ( ! $this->membership) {
-			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'));
-			return '';
-		}
-
 		$atts['membership'] = $this->membership;
 
 		return wu_get_template_contents('dashboard-widgets/invoices', $atts);

--- a/inc/ui/class-limits-element.php
+++ b/inc/ui/class-limits-element.php
@@ -240,12 +240,6 @@ class Limits_Element extends Base_Element {
 	 */
 	public function output($atts, $content = null) {
 
-		// Defensive check - setup() may have been called but site can still be null
-		if ( ! $this->site) {
-			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'));
-			return '';
-		}
-
 		$post_types = get_post_types(
 			[
 				'public' => true,


### PR DESCRIPTION
Reverts superdav42/wp-multisite-waas#159

It seems that the merge did not completely resolve the issue with my first code proposal:

<img width="617" height="1262" alt="22 08 2025" src="https://github.com/user-attachments/assets/5012003c-af25-4380-ab47-a30d3c3b8484" />

Can you take a look? I can create a temporary site if necessary.

Also following [this issue #232](https://github.com/elightup/slim-seo/issues/232), but no response for now