### PR TITLE
Fix: Add missing version parameter to _doing_it_wrong() calls

### DIFF
--- a/inc/ui/class-account-summary-element.php
+++ b/inc/ui/class-account-summary-element.php
@@ -296,7 +296,7 @@ class Account_Summary_Element extends Base_Element {
 
 		// Defensive check - setup() may have been called but site can still be null
 		if ( ! $this->site) {
-			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'));
+			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'), wu_get_version());
 			return '';
 		}
 

--- a/inc/ui/class-billing-info-element.php
+++ b/inc/ui/class-billing-info-element.php
@@ -274,7 +274,7 @@ class Billing_Info_Element extends Base_Element {
 
 		// Defensive check - setup() may have been called but membership can still be null
 		if ( ! $this->membership) {
-			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'));
+			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'), wu_get_version());
 			return '';
 		}
 

--- a/inc/ui/class-current-site-element.php
+++ b/inc/ui/class-current-site-element.php
@@ -354,7 +354,7 @@ class Current_Site_Element extends Base_Element {
 
 		// Defensive check - setup() may have been called but site can still be null
 		if ( ! $this->site) {
-			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'));
+			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'), wu_get_version());
 			return '';
 		}
 

--- a/inc/ui/class-invoices-element.php
+++ b/inc/ui/class-invoices-element.php
@@ -276,7 +276,7 @@ class Invoices_Element extends Base_Element {
 
 		// Defensive check - setup() may have been called but membership can still be null
 		if ( ! $this->membership) {
-			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'));
+			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'), wu_get_version());
 			return '';
 		}
 

--- a/inc/ui/class-limits-element.php
+++ b/inc/ui/class-limits-element.php
@@ -242,7 +242,7 @@ class Limits_Element extends Base_Element {
 
 		// Defensive check - setup() may have been called but site can still be null
 		if ( ! $this->site) {
-			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'));
+			_doing_it_wrong(__METHOD__, esc_html__('setup() or setup_preview() must be called before output().', 'multisite-ultimate'), wu_get_version());
 			return '';
 		}
 


### PR DESCRIPTION
## Summary

Adds the missing `wu_get_version()` parameter to all `_doing_it_wrong()` calls in UI elements as requested by David in PR #159.

This addresses the compatibility issue with Slim SEO plugin that processes shortcodes before WP Ultimo is fully initialized, providing better debugging information when these defensive checks are triggered.

## Changes

- Added version parameter to `_doing_it_wrong()` calls in 5 UI element classes:
  - `class-account-summary-element.php`
  - `class-billing-info-element.php`
  - `class-current-site-element.php`  
  - `class-invoices-element.php`
  - `class-limits-element.php`

## Test plan

- [x] Verify all `_doing_it_wrong()` calls now have 3 parameters
- [x] Test with Slim SEO plugin to ensure proper error reporting
- [x] Confirm no functionality regression

Fixes the issue mentioned in PR #178.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes.

- Chores
  - Improved diagnostic notices across Account Summary, Billing Info, Current Site, Invoices, and Limits UI elements by adding version context to internal warnings.
  - Enhances troubleshooting clarity when sites or memberships are missing, without altering normal behavior or display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->